### PR TITLE
Access attributes

### DIFF
--- a/src/assets/ace/mode-rkscript.js
+++ b/src/assets/ace/mode-rkscript.js
@@ -50,7 +50,7 @@ ace.define(
                     },
                     {
                         token: "entity.other.attribute-name",
-                        regex: "(?<=\\.)([_\\p{L}][_\\p{L}0-9]+)",
+                        regex: "(?<=\\.)([_\\p{L}][_\\p{L}0-9]*)",
                     },
                     {
                         token: "constant.numeric", // int

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,8 +165,8 @@ const keyWordCompleter = createCompleter(getKeys(KEYWORDS), "Schlüsselwort");
 const globalConstCompleter = createCompleter(getVals(ENV.global.const), "Globale Konstante")
 const globalFnCompleter = createCompleter(getVals(ENV.global.fn), "Globale Funktion")
 const stdClassCompleter = createCompleter([ENV.robot.cls, ENV.world.cls], "Klassen");
-const robotCompleter = createCompleter(Object.values(ENV.robot.mth), "Roboter.__");
-const worldCompleter = createCompleter(Object.values(ENV.world.mth), "Welt.__")
+const robotCompleter = createCompleter(Object.values(ENV.robot.mth).concat(Object.values(ENV.robot.attr)), "Roboter.__");
+const worldCompleter = createCompleter(Object.values(ENV.world.mth).concat(Object.values(ENV.world.attr)), "Welt.__")
 
 const allCompleters = [
     robotCompleter, 

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -444,11 +444,15 @@ export class ClassPrototype {
                             ),
                         };
                     else if (method.type === ValueAlias.NativeMethod)
-                        return {
-                            type: ValueAlias.NativeFunction,
-                            name: method.name,
-                            call: method.call.bind(receiver),
-                        };
+                        if (method.isGetter) {
+                            return method.call.bind(receiver)([]); // immediatly execute
+                        } else {
+                            return {
+                                type: ValueAlias.NativeFunction,
+                                name: method.name,
+                                call: method.call.bind(receiver),
+                            };
+                        }
                     // unreachable!
                     return method satisfies never;
                 },

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -456,6 +456,10 @@ export class ClassPrototype {
                     return method satisfies never;
                 },
                 set: (_newVal) => {
+                    if (method.type === ValueAlias.Method || method.type === ValueAlias.NativeMethod)
+                        throw new RuntimeError(`Kann die Methode '${varname}' nicht überschreiben.`);
+                    else if (method.type === ValueAlias.NativeGetter)
+                        throw new RuntimeError(`Kann das Attribut '${varname}' nicht abändern.`);
                     throw new RuntimeError(
                         `Kann die Konstante '${varname}' nicht verändern!`
                     );

--- a/src/language/runtime/values.ts
+++ b/src/language/runtime/values.ts
@@ -78,6 +78,7 @@ export interface NativeMethodVal {
     type: ValueAlias.NativeMethod;
     name: string;
     call: MethodCall;
+    isGetter: boolean;
 }
 
 export interface FunctionVal {
@@ -143,8 +144,8 @@ export function MK_NATIVE_FN(name: string, call: FunctionCall) {
     return { type: ValueAlias.NativeFunction, name, call } satisfies NativeFunctionVal;
 }
 
-export function MK_NATIVE_METHOD(name: string, call: MethodCall) {
-    return { type: ValueAlias.NativeMethod, name, call } satisfies NativeMethodVal;
+export function MK_NATIVE_METHOD(name: string, call: MethodCall, isGetter: boolean) {
+    return { type: ValueAlias.NativeMethod, name, call, isGetter } satisfies NativeMethodVal;
 }
 
 export function MK_NUMBER(n = 0) {

--- a/src/language/runtime/values.ts
+++ b/src/language/runtime/values.ts
@@ -12,6 +12,7 @@ export const enum ValueAlias {
     List = "Liste",
     NativeFunction = "NativeFunktion",
     NativeMethod = "NativeMethode",
+    NativeGetter = "NativeZugriffsmethode",
     Function = "Funktion",
     Method = "Methode",
     Class = "Klasse",
@@ -73,12 +74,18 @@ export interface NativeFunctionVal {
 }
 
 export type MethodCall = (this: ObjectVal, args: RuntimeVal[]) => RuntimeVal;
+export type GetterCall = (this: ObjectVal) => RuntimeVal;
 
 export interface NativeMethodVal {
     type: ValueAlias.NativeMethod;
     name: string;
     call: MethodCall;
-    isGetter: boolean;
+}
+
+export interface NativeGetterVal {
+    type: ValueAlias.NativeGetter;
+    name: string;
+    call: GetterCall;
 }
 
 export interface FunctionVal {
@@ -144,8 +151,12 @@ export function MK_NATIVE_FN(name: string, call: FunctionCall) {
     return { type: ValueAlias.NativeFunction, name, call } satisfies NativeFunctionVal;
 }
 
-export function MK_NATIVE_METHOD(name: string, call: MethodCall, isGetter: boolean) {
-    return { type: ValueAlias.NativeMethod, name, call, isGetter } satisfies NativeMethodVal;
+export function MK_NATIVE_METHOD(name: string, call: MethodCall) {
+    return { type: ValueAlias.NativeMethod, name, call } satisfies NativeMethodVal;
+}
+
+export function MK_NATIVE_GETTER(name: string, call: GetterCall) {
+    return { type: ValueAlias.NativeGetter, name, call } satisfies NativeGetterVal;
 }
 
 export function MK_NUMBER(n = 0) {

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -69,10 +69,16 @@ export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal {
         prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
             downcastRoboter(this);
             return m(this.r, args);
-        }))
+        }, false))
+    }
+    function mkRobotAttribute(name: string, m: (r: Robot, args: RuntimeVal[]) => RuntimeVal) {
+        prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
+            downcastRoboter(this);
+            return m(this.r, args);
+        }, true /* THIS IS A GETTER! */))
     }
 
-    mkRobotMethod(
+    mkRobotAttribute(
         ENV.robot.mth.GET_X,
         (r, args) => {
             if (args.length != 0)
@@ -81,7 +87,7 @@ export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal {
         }
     );
 
-    mkRobotMethod(
+    mkRobotAttribute(
         ENV.robot.mth.GET_Y,
         (r, args) => {
             if (args.length != 0)
@@ -90,7 +96,7 @@ export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal {
         }
     );
 
-    mkRobotMethod(
+    mkRobotAttribute(
         ENV.robot.mth.GET_DIR,
         (r, args) => {
             if (args.length != 0)

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -1,6 +1,6 @@
 import { RuntimeError } from "../errors";
 import { ClassPrototype, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
-import { MK_BOOL, MK_STRING, MK_NUMBER, RuntimeVal, BuiltinClassVal, ObjectVal, MK_NATIVE_METHOD, ValueAlias, MK_NULL } from "../language/runtime/values";
+import { MK_BOOL, MK_STRING, MK_NUMBER, RuntimeVal, BuiltinClassVal, ObjectVal, MK_NATIVE_METHOD, ValueAlias, MK_NULL, MK_NATIVE_GETTER } from "../language/runtime/values";
 import { ENV } from "../spec";
 import { easeInOutQuad, toZero, Vec2 } from "../utils";
 import { BlockType, CHAR2BLOCK, CHAR2MARKER, Field, MarkerType, World } from "./world";
@@ -69,38 +69,32 @@ export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal {
         prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
             downcastRoboter(this);
             return m(this.r, args);
-        }, false))
+        }))
     }
-    function mkRobotAttribute(name: string, m: (r: Robot, args: RuntimeVal[]) => RuntimeVal) {
-        prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
+    function mkRobotAttribute(name: string, m: (r: Robot) => RuntimeVal) {
+        prototype.declareMethod(name, MK_NATIVE_GETTER(name, function () {
             downcastRoboter(this);
-            return m(this.r, args);
-        }, true /* THIS IS A GETTER! */))
+            return m(this.r);
+        }))
     }
 
     mkRobotAttribute(
         ENV.robot.mth.GET_X,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.GET_X + `() erwartet keine Parameter!`);
+        (r) => {
             return MK_NUMBER(r.pos.x);
         }
     );
 
     mkRobotAttribute(
         ENV.robot.mth.GET_Y,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.GET_Y + `() erwartet keine Parameter!`);
+        (r) => {
             return MK_NUMBER(r.pos.y);
         }
     );
 
     mkRobotAttribute(
         ENV.robot.mth.GET_DIR,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.GET_DIR + `() erwartet keine Parameter!`);
+        (r) => {
             return MK_STRING(DIR2SHORTGER[r.dir]);
         }
     );

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -79,21 +79,21 @@ export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal {
     }
 
     mkRobotAttribute(
-        ENV.robot.mth.GET_X,
+        ENV.robot.attr.X,
         (r) => {
             return MK_NUMBER(r.pos.x);
         }
     );
 
     mkRobotAttribute(
-        ENV.robot.mth.GET_Y,
+        ENV.robot.attr.Y,
         (r) => {
             return MK_NUMBER(r.pos.y);
         }
     );
 
     mkRobotAttribute(
-        ENV.robot.mth.GET_DIR,
+        ENV.robot.attr.DIR,
         (r) => {
             return MK_STRING(DIR2SHORTGER[r.dir]);
         }

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -1,6 +1,6 @@
 import { RuntimeError, WorldError } from "../errors";
 import { ClassPrototype, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
-import { BuiltinClassVal, MK_BOOL, MK_NATIVE_METHOD, MK_NUMBER, ObjectVal, RuntimeVal, ValueAlias } from "../language/runtime/values";
+import { BuiltinClassVal, MK_BOOL, MK_NATIVE_GETTER, MK_NATIVE_METHOD, MK_NUMBER, ObjectVal, RuntimeVal, ValueAlias } from "../language/runtime/values";
 import { ENV } from "../spec";
 import { rndi } from "../utils";
 import { declareRobot, Robot } from "./robot";
@@ -85,6 +85,33 @@ export function declareWorldClass(env: GlobalEnvironment): BuiltinClassVal {
             return m(this.w, args);
         }))
     }
+    function mkWorldAttribute(name: string, m: (r: World) => RuntimeVal) {
+        prototype.declareMethod(name, MK_NATIVE_GETTER(name, function () {
+            downcastWorld(this);
+            return m(this.w);
+        }))
+    }
+
+    mkWorldAttribute(
+        ENV.world.attr.LENGTH,
+        (w) => {
+            return MK_NUMBER(w.L);
+        }
+    );
+
+    mkWorldAttribute(
+        ENV.world.attr.WIDTH,
+        (w) => {
+            return MK_NUMBER(w.W);
+        }
+    );
+
+    mkWorldAttribute(
+        ENV.world.attr.HEIGHT,
+        (w) => {
+            return MK_NUMBER(w.H);
+        }
+    );
 
     mkWorldMethod(
         ENV.world.mth.IS_GOAL_REACHED,

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -83,7 +83,7 @@ export function declareWorldClass(env: GlobalEnvironment): BuiltinClassVal {
         prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
             downcastWorld(this);
             return m(this.w, args);
-        }))
+        }, false))
     }
 
     mkWorldMethod(

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -83,7 +83,7 @@ export function declareWorldClass(env: GlobalEnvironment): BuiltinClassVal {
         prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
             downcastWorld(this);
             return m(this.w, args);
-        }, false))
+        }))
     }
 
     mkWorldMethod(

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -35,9 +35,6 @@ export const ENV = {
             DIR: "richtung"
         },
         "mth": {
-            GET_X : "x",
-            GET_Y : "y",
-            GET_DIR : "richtung",
             GET_HEIGHT: "höhe",
             STEP : "schritt",
             TURN_LEFT : "linksDrehen",
@@ -58,6 +55,11 @@ export const ENV = {
     },
     "world": {
         "cls": "Welt",
+        "attr": {
+            LENGTH: "L",
+            HEIGHT: "H",
+            WIDTH: "B",
+        },
         "mth": {
             IS_GOAL_REACHED : "fertig",
             GET_STAGE_INDEX : "teilaufgabe",

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -56,9 +56,9 @@ export const ENV = {
     "world": {
         "cls": "Welt",
         "attr": {
-            LENGTH: "L",
-            HEIGHT: "H",
-            WIDTH: "B",
+            LENGTH: "l",
+            HEIGHT: "h",
+            WIDTH: "b",
         },
         "mth": {
             IS_GOAL_REACHED : "fertig",

--- a/src/ui/structograms.ts
+++ b/src/ui/structograms.ts
@@ -17,7 +17,6 @@ import {
     AnyFromToBlock,
     AnyForInBlock,
 } from "../language/frontend/ast";
-import { ValueAlias } from "../language/runtime/values";
 import { screenshotDiv, translateOperator } from "../utils";
 import { ENV } from "../spec";
 
@@ -27,15 +26,12 @@ const ROBOT_PSEUDO_CLASS =
     <div class="struct-classname">${ENV.robot.cls}</div>
     
     <div class="struct-attributes">
-        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.robot.attr.X, `Du kannst auf das Attribut <span class="struct-ident">${ENV.robot.attr.X}</span> nicht direkt zugreifen.`) + "🔒<br>"}
-        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.robot.attr.Y, `Du kannst auf das Attribut <span class="struct-ident">${ENV.robot.attr.Y}</span> nicht direkt zugreifen.`) + "🔒<br>"}
-        <span class="struct-type">Text</span> ${makeTooltip(ENV.robot.attr.DIR, `Du kannst auf das Attribut <span class="struct-ident">${ENV.robot.attr.DIR}</span> nicht direkt zugreifen.`) + "🔒<br>"}
+        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.robot.attr.X, `Gibt die x-Koordinate des Roboters an.`) + "🔒<br>"}
+        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.robot.attr.Y, `Gibt die y-Koordinate des Roboters an.`) + "🔒<br>"}
+        <span class="struct-type">Text</span> ${makeTooltip(ENV.robot.attr.DIR,  `Gibt die Richtung an, in die der Roboter guckt, also entweder <span class="struct-string">"N"</span>, <span class="struct-string">"S"</span>, <span class="struct-string">"W"</span> oder <span class="struct-string">"N"</span>.`) + "🔒<br>"}
     </div>
     
     <div class="struct-methods">
-        ${makeTooltip(ENV.robot.mth.GET_X , `Gibt die aktuelle x-Koordinate des Roboters zurück!`) + "()<br>"}
-        ${makeTooltip(ENV.robot.mth.GET_Y, `Gibt die aktuelle y-Koordinate des Roboters zurück!`) + "()<br>"}
-        ${makeTooltip(ENV.robot.mth.GET_DIR, `Gibt die aktuelle Richtung des Roboters als Text zurück: <span class="struct-string">"N"</span>, <span class="struct-string">"S"</span>, <span class="struct-string">"W"</span> oder <span class="struct-string">"O"</span>!`) + "()<br>"}
         ${makeTooltip(ENV.robot.mth.GET_HEIGHT, `Gibt die aktuelle Höhe des Roboters als Zahl zurück. <span class="struct-literal">0</span> ist am Weltboden.`) + "()<br>"}
         <div class="struct-dot"></div>
         ${makeTooltip(ENV.robot.mth.STEP, `Der Roboter geht ein Feld nach vorne - wenn das möglich ist.`) + "()<br>"}
@@ -61,8 +57,10 @@ const WORLD_PSEUDO_CLASS =
 `<div class="struct-class">
     <div class="struct-classname">${ENV.world.cls}</div>
     
-    <div class="struct-attributes" style="text-align: center">
-        ${makeTooltip("❓", "Du musst die Attribute der Welt-Klasse nicht kennen oder benutzen.")}
+    <div class="struct-attributes">
+        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.world.attr.LENGTH, `Gibt die Länge (Westen nach Osten) der Welt an.`) + "🔒<br>"}
+        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.world.attr.WIDTH, `Gibt die Breite (Norden nach Süden) der Welt an.`) + "🔒<br>"}
+        <span class="struct-type">Zahl</span> ${makeTooltip(ENV.world.attr.HEIGHT, `Gibt die Höhe (Boden bis Decke) in Ziegeln an.`) + "🔒<br>"}
     </div>
     
     <div class="struct-methods">

--- a/src/ui/structograms.ts
+++ b/src/ui/structograms.ts
@@ -28,7 +28,7 @@ const ROBOT_PSEUDO_CLASS =
     <div class="struct-attributes">
         <span class="struct-type">Zahl</span> ${makeTooltip(ENV.robot.attr.X, `Gibt die x-Koordinate des Roboters an.`) + "🔒<br>"}
         <span class="struct-type">Zahl</span> ${makeTooltip(ENV.robot.attr.Y, `Gibt die y-Koordinate des Roboters an.`) + "🔒<br>"}
-        <span class="struct-type">Text</span> ${makeTooltip(ENV.robot.attr.DIR,  `Gibt die Richtung an, in die der Roboter guckt, also entweder <span class="struct-string">"N"</span>, <span class="struct-string">"S"</span>, <span class="struct-string">"W"</span> oder <span class="struct-string">"N"</span>.`) + "🔒<br>"}
+        <span class="struct-type">Text</span> ${makeTooltip(ENV.robot.attr.DIR,  `Gibt die Richtung an, in die der Roboter guckt, also entweder <span class="struct-string">"N"</span>, <span class="struct-string">"S"</span>, <span class="struct-string">"W"</span> oder <span class="struct-string">"O"</span>.`) + "🔒<br>"}
     </div>
     
     <div class="struct-methods">


### PR DESCRIPTION
Implemented NativeGetters in order to emulate attributes of NativeClasses like Robot and World. They should now work similarly to regular Classes.
I.e. `robot.x` will now call a getter method directly without having to write `robot.x()`