### PR TITLE
World decoration api

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -28,7 +28,7 @@
         <div id="left-panel">
             <div id="grid-container-left">
                 <div class="lc30 wsr text" id="title-bar">
-                    <img class="little-icon" src="images/p1_outline.png">&nbsp;<span>RK4&nbsp;&nbsp;<div class="version-label">BETA</div>&nbsp;&nbsp;| <a href="https://github.com/schmisev/RK4">RKBasic</a>, <a href="./?task=std_Mehrere_3x">mehrere Roboter</a> und <a href="./editor.html">Welteditor</a> |
+                    <img class="little-icon" src="images/p1_outline.png">&nbsp;RK4&nbsp;&nbsp;<div class="version-label">BETA</div>&nbsp;&nbsp;| <a href="https://github.com/schmisev/RK4">RKBasic</a>, <a href="./?task=std_Mehrere_3x">mehrere Roboter</a> und <a href="./editor.html">Welteditor</a> |
                     <button id="fold-debug" class="toggle-button" title="Zeig/verberge Debug-Bereich">&lt;-&gt;</button>
                     | <button id="thought-toggle" class="emoji-button xcheck" title="Aktiviere/deaktiviere Roboter-Gedanken">
                         <i class="fa-solid fa-cloud"></i>

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import { type Program } from "./language/frontend/ast";
-import { type GlobalEnvironment } from "./language/runtime/environment";
+import { type GlobalEnvironment } from "./language/runtime/global-environment";
 import { STD_TASKS, type Task } from "./robot/tasks";
 import { type World } from "./robot/world";
 import { type WorldProxy } from "./robot/world-proxies";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { setCodeFromQuery } from "./ui/store-code";
 // language imports
 import Parser from "./language/frontend/parser";
 import { Program } from './language/frontend/ast';
-import { GlobalEnvironment, declareGlobalEnv } from "./language/runtime/environment";
+import { GlobalEnvironment, declareGlobalEnv } from "./language/runtime/global-environment";
 import { evaluate } from "./language/runtime/interpreter";
 import { easeInQuint, getKeys, getVals, lerp, rndi, sleep } from "./utils";
 

--- a/src/language/frontend/ast.ts
+++ b/src/language/frontend/ast.ts
@@ -4,7 +4,6 @@ import { CodePosition, Token } from "./lexer";
 export const enum StmtKind {
     Program = "Programm",
     VarDeclaration = "VarDeklaration",
-    ObjDeclaration = "ObjDeklaration",
     EmptyLine = "LeereZeile",
     DocComment = "DokuKommentar",
     IfElseBlock = "WennDannBlock",
@@ -20,6 +19,7 @@ export const enum StmtKind {
     ContinueCommand = "WeiterAnweisung",
     ReturnCommand = "ZurückAnweisung",
     AssignmentExpr = "ZuweisungsAusdruck",
+    InstanceExpr = "InstanziierungsAusdruck",
     BinaryExpr = "BinärerAusdruck",
     UnaryExpr = "UnärerAusdruck",
     Identifier = "Bezeichner",
@@ -47,7 +47,6 @@ type AbruptStmt<Ctrl> = Ctrl extends AbruptStmtKind ? AbruptToStmt[Ctrl] : never
 export type Stmt<Ctrl> =
     | DocComment
     | VarDeclaration
-    | ObjDeclaration
     | IfElseBlock<Ctrl>
     | SwitchBlock<Ctrl>
     | ForBlock<Ctrl>
@@ -92,15 +91,6 @@ export interface VarDeclaration {
     ident: string;
     type: ValueAlias.Null | ValueAlias.Boolean | ValueAlias.Number | ValueAlias.Float | ValueAlias.String | ValueAlias.List | ValueAlias.Object;
     value: Expr;
-}
-
-export interface ObjDeclaration {
-    kind: StmtKind.ObjDeclaration;
-    codePos: CodePosition;
-    ident: string;
-    type: ValueAlias.Object;
-    classname: string;
-    args: Expr[];
 }
 
 export interface EmptyLine {
@@ -199,13 +189,23 @@ export interface ReturnCommand {
     value: Expr;
 }
 
-export type Expr = AssignmentExpr | BinaryExpr | UnaryExpr | Identifier | NumericLiteral | FloatLiteral | NullLiteral | BooleanLiteral | StringLiteral  | ListLiteral | MemberExpr | ComputedMemberExpr | CallExpr;
+export type Expr = AssignmentExpr | InstanceExpr | BinaryExpr | UnaryExpr | Identifier | NumericLiteral | FloatLiteral | NullLiteral | BooleanLiteral | StringLiteral  | ListLiteral | MemberExpr | ComputedMemberExpr | CallExpr;
 
 export interface AssignmentExpr {
     kind: StmtKind.AssignmentExpr;
     codePos: CodePosition;
     assigne: Expr;
     value: Expr;
+    operator: Token;
+    inParen: boolean;
+}
+
+export interface InstanceExpr {
+    kind: StmtKind.InstanceExpr;
+    codePos: CodePosition;
+    classname: string;
+    args: Expr[];
+    operator: Token;
     inParen: boolean;
 }
 
@@ -304,7 +304,7 @@ export interface ClassDefinition {
     codePos: CodePosition;
     ident: string;
     params: ParamDeclaration[];
-    attributes: (VarDeclaration | ObjDeclaration)[];
+    attributes: VarDeclaration[];
     methods: FunctionDefinition[];
 }
 
@@ -320,6 +320,7 @@ export interface FunctionDefinition {
     params: ParamDeclaration[];
     name: string;
     body: Stmt<StmtKind.ReturnCommand>[];
+    returnType: ValueAlias;
 }
 
 export interface ExtMethodDefinition {
@@ -329,4 +330,5 @@ export interface ExtMethodDefinition {
     name: string;
     classname: string;
     body: Stmt<StmtKind.ReturnCommand>[];
+    returnType: ValueAlias;
 }

--- a/src/language/frontend/lexer.ts
+++ b/src/language/frontend/lexer.ts
@@ -18,7 +18,7 @@ export enum TokenType {
     DeclNumber, DeclFloat, DeclBoolean, DeclString, DeclList,
     DeclObject, Self, DotOp,
     If, Then, IfElse, Else,
-    Return,
+    Return, Yield,
     Repeat, RepTimes, RepWhile, RepAlways, Break, Continue, From, To, In,
     Switch, Case,
 
@@ -74,7 +74,9 @@ export const KEYWORDS: Record<string, TokenType> = {
     sonst: TokenType.Else,
     ist: TokenType.Assign,
     sei: TokenType.Assign,
-    als: TokenType.Instance,
+    neues: TokenType.Instance,
+    neue: TokenType.Instance,
+    neuer: TokenType.Instance,
     wiederhole: TokenType.Repeat,
     solange: TokenType.RepWhile,
     mal: TokenType.RepTimes,
@@ -91,6 +93,7 @@ export const KEYWORDS: Record<string, TokenType> = {
     von: TokenType.From,
     bis: TokenType.To,
     in: TokenType.In,
+    ergibt: TokenType.Yield,
 
     unterscheide: TokenType.Switch,
     falls: TokenType.Case,

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -417,7 +417,7 @@ export class Environment implements StaticScope {
 
     public declareInternalClass<C>(
         clsName: string,
-        clsContructor: (args: RuntimeVal[]) => C,
+        clsContructor: ((args: RuntimeVal[]) => C) | null,
         clsMethods: Record<string, (o: C, args: RuntimeVal[]) => RuntimeVal>,
         clsAttributes: Record<string, (o: C) => RuntimeVal>,
     ) {

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -117,24 +117,25 @@ export class Environment implements StaticScope {
         return jump(() => this._parent!.resolveVarImpl(varname));
     }
 
-    public instanceNativeObject<C>(
+    // no type checking yet, you are on your own
+    public instanceNativeObject(
         clsName: string,
         args: RuntimeVal[]
-    ): NativeObjectVal<C> {
+    ): NativeObjectVal<unknown> {
         let cls = this.lookupVar(clsName);
         if (cls.type !== ValueAlias.Class)
             throw `'${clsName}' ist kein Klassenname!`;
         if (!cls.internal)
             throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
 
-        // this is a bit of a cheat.
-        return instanceNativeObjectFromClass<C>(cls as BuiltinClassVal<C>, args);
+        return instanceNativeObjectFromClass(cls, args);
     }
 
-    public wrapNativeObject<C>(
+    // no type checking yet, you are on your own
+    public wrapNativeObject(
         clsName: string,
-        obj: C,
-    ): NativeObjectVal<C> {
+        obj: unknown,
+    ): NativeObjectVal<unknown> {
         let cls = this.lookupVar(clsName);
         if (cls.type !== ValueAlias.Class)
             throw `'${clsName}' ist kein Klassenname!`;
@@ -142,7 +143,7 @@ export class Environment implements StaticScope {
             throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
         
         const ownMembers = new VarHolder();
-        const nativeObj: NativeObjectVal<C> = {
+        const nativeObj: NativeObjectVal<unknown> = {
             type: ValueAlias.Object,
             cls,
             ownMembers,

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -127,7 +127,8 @@ export class Environment implements StaticScope {
         if (!cls.internal)
             throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
 
-        return instanceNativeObjectFromClass(cls, args);
+        // this is a bit of a cheat.
+        return instanceNativeObjectFromClass<C>(cls as BuiltinClassVal<C>, args);
     }
 
     public wrapNativeObject<C>(

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -1,316 +1,18 @@
 import { RuntimeError } from "../../errors";
-import { declareSphereClass } from "../../robot/addons/bodies";
-import { declareRobotClass, Robot } from "../../robot/robot";
-import { declareWorldClass, World } from "../../robot/world";
-import { ENV } from "../../spec";
-import { formatValue } from "../../utils";
-import { Trampoline, jump, jumpAround, jumpBind, land } from "./trampoline";
+import { jumpAround, Trampoline, land, jump, jumpBind } from "./trampoline";
 import {
+    MethodVal,
+    NativeMethodVal,
+    NativeGetterVal,
+    ObjectVal,
+    RuntimeVal,
+    ValueAlias,
     BuiltinClassVal,
-    ClassVal,
-    MK_FLOAT,
     MK_NATIVE_GETTER,
     MK_NATIVE_METHOD,
-    MK_STRING,
-    MethodVal,
-    NativeGetterVal,
-    NativeMethodVal,
-    ObjectVal,
-    ValueAlias,
-    isLikeNumber,
-    MK_BOOL,
-    MK_NATIVE_FN,
-    MK_NULL,
-    MK_NUMBER,
-    RuntimeVal,
 } from "./values";
 
-export interface GlobalEnvironment extends Environment {
-    // global env holds some special values that we don't want to lookup by name
-    readonly robotClass: ClassVal;
-    readonly worldClass: ClassVal;
-}
-
-export function declareGlobalEnv(): GlobalEnvironment {
-    class GlobalEnvironment extends Environment {
-        private _robotClass: BuiltinClassVal<Robot> = declareRobotClass(this);
-        private _worldClass: BuiltinClassVal<World> = declareWorldClass(this);
-
-        constructor() {
-            super();
-            declareSphereClass(this);
-        }
-
-        get robotClass() {
-            return this._robotClass;
-        }
-        get worldClass() {
-            return this._worldClass;
-        }
-    }
-    const env = new GlobalEnvironment();
-    env.declareVar(ENV.global.const.TRUE, MK_BOOL(true), true);
-    env.declareVar(ENV.global.const.FALSE, MK_BOOL(false), true);
-    env.declareVar(ENV.global.const.NULL, MK_NULL(), true);
-    env.declareVar(ENV.global.const.YELLOW, MK_STRING("Y"), true);
-    env.declareVar(ENV.global.const.RED, MK_STRING("R"), true);
-    env.declareVar(ENV.global.const.GREEN, MK_STRING("G"), true);
-    env.declareVar(ENV.global.const.BLUE, MK_STRING("B"), true);
-
-    env.declareVar(
-        ENV.global.fn.RANDOM_NUMBER,
-        MK_NATIVE_FN(ENV.global.fn.RANDOM_NUMBER, (args) => {
-            let r = 0;
-            let b = 0;
-            if (args.length == 0) {
-                r = 1;
-            } else if (args.length <= 2) {
-                let v1 = args[0];
-                if (v1.type !== ValueAlias.Number)
-                    throw new RuntimeError(
-                        `Erwarte mindestens Zahl als Parameter, nicht '${args[0].type}'!`
-                    );
-                r = v1.value;
-
-                if (args.length == 2) {
-                    let v2 = args[1];
-                    if (v2.type !== ValueAlias.Number)
-                        throw new RuntimeError(
-                            `Erwarte zwei (Komma-)zahlen als Parameter, nicht '${args[0].type}' und '${args[1].type}'!`
-                        );
-                    r = v2.value - v1.value;
-                    b = v1.value;
-                }
-            } else throw new RuntimeError(`Zu viele Parameter!`);
-
-            const n = b + Math.floor(Math.random() * r);
-            return MK_NUMBER(n);
-        }),
-        true
-    );
-
-    env.declareVar(
-        ENV.global.fn.RANDOM_FLOAT,
-        MK_NATIVE_FN(ENV.global.fn.RANDOM_FLOAT, (args) => {
-            let r = 0;
-            let b = 0;
-            if (args.length == 0) {
-                r = 1;
-            } else if (args.length <= 2) {
-                let v1 = args[0];
-                if (!isLikeNumber(v1))
-                    throw new RuntimeError(
-                        `Erwarte mindestens (Komma-)zahl als Parameter, nicht '${args[0].type}'!`
-                    );
-                r = v1.value;
-
-                if (args.length == 2) {
-                    let v2 = args[1];
-                    if (!isLikeNumber(v2))
-                        throw new RuntimeError(
-                            `Erwarte zwei (Komma-)zahlen als Parameter, nicht '${args[0].type}' und '${args[1].type}'!`
-                        );
-                    r = v2.value - v1.value;
-                    b = v1.value;
-                }
-            } else throw new RuntimeError(`Zu viele Parameter!`);
-
-            const n = b + Math.random() * r;
-            return MK_FLOAT(n);
-        }),
-        true
-    );
-
-    env.declareVar(
-        ENV.global.fn.LENGTH,
-        MK_NATIVE_FN(ENV.global.fn.LENGTH, (args) => {
-            if (args.length != 1)
-                throw new RuntimeError(`Erwarte genau eine Liste als Eingabe!`);
-            if (args[0].type != ValueAlias.List)
-                throw new RuntimeError(`Erwarte eine Liste als Eingabe!`);
-            return MK_NUMBER(args[0].elements.length);
-        }),
-        true
-    );
-
-    env.declareVar(
-        ENV.global.fn.TO_TEXT,
-        MK_NATIVE_FN(ENV.global.fn.TO_TEXT, (args) => {
-            if (args.length != 1)
-                throw new RuntimeError(`Erwarte genau einen Eingabewert!`);
-            return MK_STRING(formatValue(args[0]));
-        }),
-        true
-    );
-
-    env.declareVar(
-        ENV.global.fn.JOIN,
-        MK_NATIVE_FN(ENV.global.fn.JOIN, (args) => {
-            if (args.length == 0) return MK_STRING("");
-            if (args[0].type != ValueAlias.String)
-                throw new RuntimeError("Erwarte einen Text als erste Eingabe!");
-            const [sep, ...rest] = args;
-            return MK_STRING(rest.map((v) => formatValue(v)).join(sep.value));
-        }),
-        true
-    );
-
-    env.declareVar(
-        ENV.global.fn.TO_INT,
-        MK_NATIVE_FN(ENV.global.fn.TO_INT, (args) => {
-            if (
-                args.length === 0 ||
-                args.length > 1 ||
-                (args[0].type != ValueAlias.Number &&
-                    args[0].type != ValueAlias.Float)
-            )
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-            return MK_NUMBER(Math.trunc(args[0].value));
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.TO_FLOAT,
-        MK_NATIVE_FN(ENV.global.fn.TO_FLOAT, (args) => {
-            if (
-                args.length === 0 ||
-                args.length > 1 ||
-                (args[0].type != ValueAlias.Number &&
-                    args[0].type != ValueAlias.Float)
-            )
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-            return MK_FLOAT(args[0].value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.TRUNC,
-        MK_NATIVE_FN(ENV.global.fn.TRUNC, (args) => {
-            if (
-                args.length === 0 ||
-                args.length > 1 ||
-                args[0].type != ValueAlias.Float
-            )
-                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let { value, type } = args[0];
-            value = Math.trunc(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.CEIL,
-        MK_NATIVE_FN(ENV.global.fn.CEIL, (args) => {
-            if (
-                args.length === 0 ||
-                args.length > 1 ||
-                args[0].type != ValueAlias.Float
-            )
-                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let { value, type } = args[0];
-            value = Math.ceil(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.FLOOR,
-        MK_NATIVE_FN(ENV.global.fn.FLOOR, (args) => {
-            if (
-                args.length === 0 ||
-                args.length > 1 ||
-                args[0].type != ValueAlias.Float
-            )
-                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let { value, type } = args[0];
-            value = Math.floor(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.ROUND,
-        MK_NATIVE_FN(ENV.global.fn.ROUND, (args) => {
-            if (
-                args.length === 0 ||
-                args.length > 1 ||
-                args[0].type != ValueAlias.Float
-            )
-                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let { value, type } = args[0];
-            value = Math.round(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.SIN,
-        MK_NATIVE_FN(ENV.global.fn.SIN, (args) => {
-            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-            let { value, type } = args[0];
-            value = Math.sin(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.COS,
-        MK_NATIVE_FN(ENV.global.fn.COS, (args) => {
-            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-            let { value, type } = args[0];
-            value = Math.cos(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.TAN,
-        MK_NATIVE_FN(ENV.global.fn.TAN, (args) => {
-            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-            let { value, type } = args[0];
-            value = Math.tan(value);
-            return MK_FLOAT(value);
-        })
-    );
-
-    env.declareVar(
-        ENV.global.fn.ABS,
-        MK_NATIVE_FN(ENV.global.fn.ABS, (args) => {
-            if (args.length === 0 || args.length > 1)
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-            let val = args[0];
-            if (val.type === ValueAlias.Number)
-                return MK_NUMBER(Math.abs(val.value));
-            else if (val.type === ValueAlias.Float)
-                return MK_FLOAT(Math.abs(val.value));
-            else
-                throw new RuntimeError(
-                    "Erwarte eine (Komma-)zahl als Eingabe!"
-                );
-        })
-    );
-
-    env.declareVar(ENV.robot.cls, env.robotClass, true);
-    env.declareVar(ENV.world.cls, env.worldClass, true);
-    return env;
-}
-
-interface ScopeMemberDefinition {
+export interface ScopeMemberDefinition {
     get(): RuntimeVal;
     set(val: RuntimeVal): void;
 }
@@ -415,102 +117,42 @@ export class Environment implements StaticScope {
         return jump(() => this._parent!.resolveVarImpl(varname));
     }
 
-    public declareInternalClass<C>(
+    public instanceNativeObject<C>(
         clsName: string,
-        clsContructor: ((args: RuntimeVal[]) => C) | null,
-        clsMethods: Record<string, (o: C, args: RuntimeVal[]) => RuntimeVal>,
-        clsAttributes: Record<string, (o: C) => RuntimeVal>,
-    ) {
-        const prototype = new ClassPrototype();
-        const cls: BuiltinClassVal<C> = {
-            type: ValueAlias.Class,
-            name: clsName,
-            internal: true,
-            prototype,
-            internalConstructor: clsContructor,
-        };
+        args: RuntimeVal[]
+    ): NativeObjectVal<C> {
+        let cls = this.lookupVar(clsName);
+        if (cls.type !== ValueAlias.Class)
+            throw `'${clsName}' ist kein Klassenname!`;
+        if (!cls.internal)
+            throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
 
-        function downcastClass(self: ObjectVal): asserts self is ProxyObjectVal<C> {
-            if (!Object.is(self.cls, cls))
-                throw new RuntimeError(
-                    `Diese Methode kann nur auf '${cls.name}' ausgeführt werden.`
-                );
-        }
-
-        function mkClassMethod(
-            name: string,
-            m: (o: C, args: RuntimeVal[]) => RuntimeVal
-        ) {
-            prototype.declareMethod(
-                name,
-                MK_NATIVE_METHOD(name, function (args) {
-                    downcastClass(this);
-                    return m(this.o, args);
-                })
-            );
-        }
-
-        function mkClassAttribute(name: string, m: (o: C) => RuntimeVal) {
-            prototype.declareMethod(
-                name,
-                MK_NATIVE_GETTER(name, function () {
-                    downcastClass(this);
-                    return m(this.o);
-                })
-            );
-        }
-
-        // insert methods into class
-        for (const methodName in clsMethods) {
-            mkClassMethod(methodName, clsMethods[methodName]);
-        }
-
-        // insert attributes (getters) into class
-        for (const attributeName in clsAttributes) {
-            mkClassAttribute(attributeName, clsAttributes[attributeName]);
-        }
-
-        this.declareVar(clsName, cls, true);
-        return cls;
+        return instanceNativeObjectFromClass(cls, args);
     }
 
-    public  wrapProxyObject<C>(o: C, clsName: string): ProxyObjectVal<C> {
+    public wrapNativeObject<C>(
+        clsName: string,
+        obj: C,
+    ): NativeObjectVal<C> {
         let cls = this.lookupVar(clsName);
-        if (cls.type !== ValueAlias.Class) throw `'${clsName}' ist kein Klassenname!`;
+        if (cls.type !== ValueAlias.Class)
+            throw `'${clsName}' ist kein Klassenname!`;
+        if (!cls.internal)
+            throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
         
         const ownMembers = new VarHolder();
-        const obj: ProxyObjectVal<C> = {
+        const nativeObj: NativeObjectVal<C> = {
             type: ValueAlias.Object,
             cls,
             ownMembers,
-            o,
-        };
-        return obj;
-    }
+            nativeRepr: obj,
+        }
 
-    public instanceProxyObject<C>(clsName: string, args: RuntimeVal[]): ProxyObjectVal<C> {
-        let cls = this.lookupVar(clsName);
-        if (cls.type !== ValueAlias.Class) throw `'${clsName}' ist kein Klassenname!`;
-        if (!cls.internal || !cls.internalConstructor) throw `Die Klasse '${clsName}' ist nicht instanziierbar!`;
-
-        const ownMembers = new VarHolder();
-        const obj: ProxyObjectVal<C> = {
-            type: ValueAlias.Object,
-            cls,
-            ownMembers,
-            o: cls.internalConstructor(args),
-        };
-        return obj;
-    }
-
-    public declareProxyObject<C>(o: C, varname: string, clsName: string, env: Environment): C {
-        // add object to environment
-        env.declareVar(varname, this.wrapProxyObject(o, clsName), true);
-        return o;
+        return nativeObj;
     }
 }
 
-function resolveDynamicVar(
+export function resolveDynamicVar(
     receiver: ObjectVal,
     varname: string,
     fallback?: StaticScope
@@ -604,9 +246,8 @@ export class ClassPrototype {
                             ),
                         };
                     else if (method.type === ValueAlias.NativeGetter)
-                        return method.call.bind(
-                            receiver
-                        )(); // return underlying value
+                        return method.call.bind(receiver)();
+                    // return underlying value
                     else if (method.type === ValueAlias.NativeMethod)
                         return {
                             type: ValueAlias.NativeFunction,
@@ -638,9 +279,88 @@ export class ClassPrototype {
     }
 }
 
-
 // General internal class declarations
-export interface ProxyObjectVal<C> extends ObjectVal {
-    o: C;
+export interface NativeObjectVal<C> extends ObjectVal {
+    nativeRepr: C;
+}
+export function createInternalClass<C>({
+    clsName,
+    clsConstructor,
+    clsMethods = {},
+    clsAttributes = {},
+}: {
+    clsName: string;
+    clsConstructor?: (args: RuntimeVal[]) => C;
+    clsMethods?: Record<string, (self: C, args: RuntimeVal[]) => RuntimeVal>;
+    clsAttributes?: Record<string, (self: C) => RuntimeVal>;
+}) {
+    const prototype = new ClassPrototype();
+    const cls: BuiltinClassVal<C> = {
+        type: ValueAlias.Class,
+        name: clsName,
+        internal: true,
+        prototype,
+        internalConstructor: clsConstructor,
+    };
+
+    function downcastClass(
+        self: ObjectVal
+    ): asserts self is NativeObjectVal<C> {
+        if (!Object.is(self.cls, cls))
+            throw new RuntimeError(
+                `Diese Methode kann nur auf '${cls.name}' ausgeführt werden.`
+            );
+    }
+
+    function mkClassMethod(
+        name: string,
+        m: (o: C, args: RuntimeVal[]) => RuntimeVal
+    ) {
+        prototype.declareMethod(
+            name,
+            MK_NATIVE_METHOD(name, function (args) {
+                downcastClass(this);
+                return m(this.nativeRepr, args);
+            })
+        );
+    }
+
+    function mkClassAttribute(name: string, m: (o: C) => RuntimeVal) {
+        prototype.declareMethod(
+            name,
+            MK_NATIVE_GETTER(name, function () {
+                downcastClass(this);
+                return m(this.nativeRepr);
+            })
+        );
+    }
+
+    // insert methods into class
+    for (const methodName in clsMethods) {
+        mkClassMethod(methodName, clsMethods[methodName]);
+    }
+
+    // insert attributes (getters) into class
+    for (const attributeName in clsAttributes) {
+        mkClassAttribute(attributeName, clsAttributes[attributeName]);
+    }
+
+    return cls;
 }
 
+export function instanceNativeObjectFromClass<C>(
+    cls: BuiltinClassVal<C>,
+    args: RuntimeVal[]
+): NativeObjectVal<C> {
+    if (!cls.internalConstructor)
+        throw `Die Klasse '${cls.name}' hat keinen Konstruktor!`;
+
+    const ownMembers = new VarHolder();
+    const obj: NativeObjectVal<C> = {
+        type: ValueAlias.Object,
+        cls,
+        ownMembers,
+        nativeRepr: cls.internalConstructor(args),
+    };
+    return obj;
+}

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -1,4 +1,5 @@
 import { RuntimeError } from "../../errors";
+import { declareSphereClass } from "../../robot/addons/bodies";
 import { declareRobotClass } from "../../robot/robot";
 import { declareWorldClass } from "../../robot/world";
 import { ENV } from "../../spec";
@@ -8,16 +9,15 @@ import {
     BuiltinClassVal,
     ClassVal,
     MK_FLOAT,
+    MK_NATIVE_GETTER,
+    MK_NATIVE_METHOD,
     MK_STRING,
     MethodVal,
     NativeGetterVal,
     NativeMethodVal,
-    NumberLikeVal,
     ObjectVal,
     ValueAlias,
     isLikeNumber,
-} from "./values";
-import {
     MK_BOOL,
     MK_NATIVE_FN,
     MK_NULL,
@@ -29,17 +29,23 @@ export interface GlobalEnvironment extends Environment {
     // global env holds some special values that we don't want to lookup by name
     readonly robotClass: ClassVal;
     readonly worldClass: ClassVal;
+    readonly sphereClass: ClassVal;
 }
 
 export function declareGlobalEnv(): GlobalEnvironment {
     class GlobalEnvironment extends Environment {
         private _robotClass: BuiltinClassVal = declareRobotClass(this);
         private _worldClass: BuiltinClassVal = declareWorldClass(this);
+        public _sphereClass: BuiltinClassVal = declareSphereClass(this);
+
         get robotClass() {
             return this._robotClass;
         }
         get worldClass() {
             return this._worldClass;
+        }
+        get sphereClass() {
+            return this._sphereClass;
         }
     }
     const env = new GlobalEnvironment();
@@ -152,7 +158,15 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.TO_INT,
         MK_NATIVE_FN(ENV.global.fn.TO_INT, (args) => {
-            if ((args.length === 0 || args.length > 1) || (args[0].type != ValueAlias.Number && args[0].type != ValueAlias.Float)) throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                (args[0].type != ValueAlias.Number &&
+                    args[0].type != ValueAlias.Float)
+            )
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
             return MK_NUMBER(Math.trunc(args[0].value));
         })
     );
@@ -160,7 +174,15 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.TO_FLOAT,
         MK_NATIVE_FN(ENV.global.fn.TO_FLOAT, (args) => {
-            if ((args.length === 0 || args.length > 1) || (args[0].type != ValueAlias.Number && args[0].type != ValueAlias.Float)) throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                (args[0].type != ValueAlias.Number &&
+                    args[0].type != ValueAlias.Float)
+            )
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
             return MK_FLOAT(args[0].value);
         })
     );
@@ -168,8 +190,13 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.TRUNC,
         MK_NATIVE_FN(ENV.global.fn.TRUNC, (args) => {
-            if ((args.length === 0 || args.length > 1) || args[0].type != ValueAlias.Float) throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let {value, type} = args[0];
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
             value = Math.trunc(value);
             return MK_FLOAT(value);
         })
@@ -178,8 +205,13 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.CEIL,
         MK_NATIVE_FN(ENV.global.fn.CEIL, (args) => {
-            if ((args.length === 0 || args.length > 1) || args[0].type != ValueAlias.Float) throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let {value, type} = args[0];
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
             value = Math.ceil(value);
             return MK_FLOAT(value);
         })
@@ -188,8 +220,13 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.FLOOR,
         MK_NATIVE_FN(ENV.global.fn.FLOOR, (args) => {
-            if ((args.length === 0 || args.length > 1) || args[0].type != ValueAlias.Float) throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let {value, type} = args[0];
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
             value = Math.floor(value);
             return MK_FLOAT(value);
         })
@@ -198,8 +235,13 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.ROUND,
         MK_NATIVE_FN(ENV.global.fn.ROUND, (args) => {
-            if ((args.length === 0 || args.length > 1) || args[0].type != ValueAlias.Float) throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
-            let {value, type} = args[0];
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
             value = Math.round(value);
             return MK_FLOAT(value);
         })
@@ -208,8 +250,11 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.SIN,
         MK_NATIVE_FN(ENV.global.fn.SIN, (args) => {
-            if ((args.length === 0 || args.length > 1) || !isLikeNumber(args[0])) throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
-            let {value, type} = args[0];
+            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let { value, type } = args[0];
             value = Math.sin(value);
             return MK_FLOAT(value);
         })
@@ -218,8 +263,11 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.COS,
         MK_NATIVE_FN(ENV.global.fn.COS, (args) => {
-            if ((args.length === 0 || args.length > 1) || !isLikeNumber(args[0])) throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
-            let {value, type} = args[0];
+            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let { value, type } = args[0];
             value = Math.cos(value);
             return MK_FLOAT(value);
         })
@@ -228,8 +276,11 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.TAN,
         MK_NATIVE_FN(ENV.global.fn.TAN, (args) => {
-            if ((args.length === 0 || args.length > 1) || !isLikeNumber(args[0])) throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
-            let {value, type} = args[0];
+            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let { value, type } = args[0];
             value = Math.tan(value);
             return MK_FLOAT(value);
         })
@@ -238,11 +289,19 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(
         ENV.global.fn.ABS,
         MK_NATIVE_FN(ENV.global.fn.ABS, (args) => {
-            if ((args.length === 0 || args.length > 1)) throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
+            if (args.length === 0 || args.length > 1)
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
             let val = args[0];
-            if (val.type === ValueAlias.Number) return MK_NUMBER(Math.abs(val.value));
-            else if (val.type === ValueAlias.Float) return MK_FLOAT(Math.abs(val.value));
-            else throw new RuntimeError("Erwarte eine (Komma-)zahl als Eingabe!");
+            if (val.type === ValueAlias.Number)
+                return MK_NUMBER(Math.abs(val.value));
+            else if (val.type === ValueAlias.Float)
+                return MK_FLOAT(Math.abs(val.value));
+            else
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
         })
     );
 
@@ -391,9 +450,15 @@ export class BoundDynamicScope implements StaticScope {
 }
 
 export class ClassPrototype {
-    private _methods: Map<string, MethodVal | NativeMethodVal | NativeGetterVal> = new Map();
+    private _methods: Map<
+        string,
+        MethodVal | NativeMethodVal | NativeGetterVal
+    > = new Map();
 
-    public declareMethod(name: string, method: MethodVal | NativeMethodVal | NativeGetterVal) {
+    public declareMethod(
+        name: string,
+        method: MethodVal | NativeMethodVal | NativeGetterVal
+    ) {
         if (this._methods.has(name))
             throw new RuntimeError(`Die Methode '${name}' existiert schon!`);
         this._methods.set(name, method);
@@ -445,7 +510,9 @@ export class ClassPrototype {
                             ),
                         };
                     else if (method.type === ValueAlias.NativeGetter)
-                        return method.call.bind(receiver)(); // return underlying value
+                        return method.call.bind(
+                            receiver
+                        )(); // return underlying value
                     else if (method.type === ValueAlias.NativeMethod)
                         return {
                             type: ValueAlias.NativeFunction,
@@ -456,10 +523,17 @@ export class ClassPrototype {
                     return method satisfies never;
                 },
                 set: (_newVal) => {
-                    if (method.type === ValueAlias.Method || method.type === ValueAlias.NativeMethod)
-                        throw new RuntimeError(`Kann die Methode '${varname}' nicht überschreiben.`);
+                    if (
+                        method.type === ValueAlias.Method ||
+                        method.type === ValueAlias.NativeMethod
+                    )
+                        throw new RuntimeError(
+                            `Kann die Methode '${varname}' nicht überschreiben.`
+                        );
                     else if (method.type === ValueAlias.NativeGetter)
-                        throw new RuntimeError(`Kann das Attribut '${varname}' nicht abändern.`);
+                        throw new RuntimeError(
+                            `Kann das Attribut '${varname}' nicht abändern.`
+                        );
                     throw new RuntimeError(
                         `Kann die Konstante '${varname}' nicht verändern!`
                     );
@@ -468,4 +542,85 @@ export class ClassPrototype {
         }
         return land(undefined);
     }
+}
+
+
+// API helper
+export interface ProxyObjectVal<C> extends ObjectVal {
+    o: C;
+}
+
+export function declareGeneralClass<C>(
+    clsName: string,
+    clsMethods: Record<string, (o: C, args: RuntimeVal[]) => RuntimeVal>,
+    clsAttributes: Record<string, (o: C) => RuntimeVal>,
+    env: GlobalEnvironment
+) {
+    const prototype = new ClassPrototype();
+    const cls: BuiltinClassVal = {
+        type: ValueAlias.Class,
+        name: clsName,
+        internal: true,
+        prototype,
+    };
+
+    function downcastClass(self: ObjectVal): asserts self is ProxyObjectVal<C> {
+        if (!Object.is(self.cls, cls))
+            throw new RuntimeError(
+                `Diese Methode kann nur auf '${cls.name}' ausgeführt werden.`
+            );
+    }
+
+    function mkClassMethod(
+        name: string,
+        m: (o: C, args: RuntimeVal[]) => RuntimeVal
+    ) {
+        prototype.declareMethod(
+            name,
+            MK_NATIVE_METHOD(name, function (args) {
+                downcastClass(this);
+                return m(this.o, args);
+            })
+        );
+    }
+
+    function mkClassAttribute(name: string, m: (o: C) => RuntimeVal) {
+        prototype.declareMethod(
+            name,
+            MK_NATIVE_GETTER(name, function () {
+                downcastClass(this);
+                return m(this.o);
+            })
+        );
+    }
+
+    // insert method into class
+    for (const methodName in clsMethods) {
+        mkClassMethod(methodName, clsMethods[methodName]);
+    }
+
+    // insert attributes (getters) into class
+    for (const attributeName in clsAttributes) {
+        mkClassAttribute(attributeName, clsAttributes[attributeName]);
+    }
+
+    return cls;
+}
+
+export function createGeneralObjectOfClass<C>(o: C, cls: ClassVal): ProxyObjectVal<C> {
+    const env = new VarHolder();
+    const obj: ProxyObjectVal<C> = {
+        type: ValueAlias.Object,
+        cls,
+        ownMembers: env,
+        o,
+    };
+
+    return obj;
+}
+
+export function declareGeneralObject<C>(o: C, cls: ClassVal, varname: string, env: GlobalEnvironment): C {
+    // add object to environment
+    env.declareVar(varname, createGeneralObjectOfClass(o, cls), true);
+    return o;
 }

--- a/src/language/runtime/environment.ts
+++ b/src/language/runtime/environment.ts
@@ -118,24 +118,24 @@ export class Environment implements StaticScope {
     }
 
     // no type checking yet, you are on your own
-    public instanceNativeObject(
+    public instanceNativeObject<C>(
         clsName: string,
         args: RuntimeVal[]
-    ): NativeObjectVal<unknown> {
+    ): NativeObjectVal<C> {
         let cls = this.lookupVar(clsName);
         if (cls.type !== ValueAlias.Class)
             throw `'${clsName}' ist kein Klassenname!`;
         if (!cls.internal)
             throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
 
-        return instanceNativeObjectFromClass(cls, args);
+        return instanceNativeObjectFromClass(cls as BuiltinClassVal<C>, args);
     }
 
     // no type checking yet, you are on your own
-    public wrapNativeObject(
+    public wrapNativeObject<C>(
         clsName: string,
-        obj: unknown,
-    ): NativeObjectVal<unknown> {
+        obj: C,
+    ): NativeObjectVal<C> {
         let cls = this.lookupVar(clsName);
         if (cls.type !== ValueAlias.Class)
             throw `'${clsName}' ist kein Klassenname!`;
@@ -143,7 +143,7 @@ export class Environment implements StaticScope {
             throw `'${clsName}' ist keine interne Klasse und sollte nicht auf diesem Weg instaziiert werden.`;
         
         const ownMembers = new VarHolder();
-        const nativeObj: NativeObjectVal<unknown> = {
+        const nativeObj: NativeObjectVal<C> = {
             type: ValueAlias.Object,
             cls,
             ownMembers,

--- a/src/language/runtime/eval/expressions.ts
+++ b/src/language/runtime/eval/expressions.ts
@@ -189,7 +189,7 @@ export function eval_numeric_binary_expr(
         return MK_BOOL(lhs.value <= rhs.value);
     } else if (operator.type == TokenType.NEQ) {
         return MK_BOOL(lhs.value != rhs.value);
-    } else if (lhs.type !== rhs.type) {
+    } else if (lhs.type === ValueAlias.Float || rhs.type === ValueAlias.Float) {
         // cast to float
         if (operator.type == TokenType.Plus) {
             return MK_FLOAT(lhs.value + rhs.value);

--- a/src/language/runtime/eval/expressions.ts
+++ b/src/language/runtime/eval/expressions.ts
@@ -1,7 +1,8 @@
 import { RuntimeError } from "../../../errors";
-import { Identifier, BinaryExpr, UnaryExpr, AssignmentExpr, CallExpr, MemberExpr, StmtKind, ListLiteral, ComputedMemberExpr } from "../../frontend/ast";
+import { formatValue } from "../../../utils";
+import { Identifier, BinaryExpr, UnaryExpr, AssignmentExpr, CallExpr, MemberExpr, StmtKind, ListLiteral, ComputedMemberExpr, InstanceExpr } from "../../frontend/ast";
 import { CodePosition, Token, TokenType } from "../../frontend/lexer";
-import { Environment } from "../environment";
+import { Environment, VarHolder } from "../environment";
 import { SteppedEval, evaluate_expr } from "../interpreter";
 import {
     RuntimeVal,
@@ -19,7 +20,7 @@ import {
     FloatVal,
     MK_FLOAT,
 } from "../values";
-import { eval_bare_statements } from "./statements";
+import { eval_bare_statements, eval_var_declaration } from "./statements";
 
 export function eval_identifier(
     ident: Identifier,
@@ -110,6 +111,64 @@ export function* eval_assignment_expr(
     throw new RuntimeError(
         `Kann den Wert von '${node.assigne.kind}' nicht ändern!`, node.codePos
     );
+}
+
+export function* eval_instance_expr(
+    decl: InstanceExpr,
+    evalEnv: Environment,
+    declEnv: Environment | VarHolder = evalEnv
+): SteppedEval<RuntimeVal> {
+    const cl = evalEnv.lookupVar(decl.classname);
+    if (cl.type != ValueAlias.Class)
+        throw new RuntimeError(
+            `'${decl.classname}' ist kein Klassenname!`,
+            decl.codePos
+        );
+    if (cl.internal)
+        throw new RuntimeError(
+            `Kann kein neues Objekt der Klasse '${decl.classname}' erzeugen.`,
+            decl.codePos
+        );
+
+    const obj: ObjectVal = {
+        type: ValueAlias.Object,
+        cls: cl,
+        ownMembers: new VarHolder(),
+    };
+
+    // calculate arguments of constructor
+    const args: RuntimeVal[] = [];
+    for (const expr of decl.args) {
+        const result = yield* evaluate_expr(expr, evalEnv);
+        args.push(result);
+    }
+
+    const constructorEnv = new Environment(evalEnv);
+
+    // create variables
+    if (args.length != cl.params.length)
+        throw new RuntimeError(
+            `Erwarte ${cl.params.length} Parameter, habe aber ${args.length} erhalten!`,
+            decl.codePos
+        );
+    for (let i = 0; i < cl.params.length; i++) {
+        const param = cl.params[i];
+        const varname = param.ident;
+        const arg = args[i];
+
+        if (param.type != arg.type)
+            throw new RuntimeError(
+                `'${varname}' sollte '${param.type}' sein, ist aber '${arg.type}'`,
+                decl.codePos
+            );
+        constructorEnv.declareVar(varname, args[i]);
+    }
+
+    for (const attr of cl.attributes) {
+        yield* eval_var_declaration(attr, constructorEnv, obj.ownMembers);
+    }
+    
+    return obj;
 }
 
 export function* eval_binary_expr(
@@ -359,13 +418,17 @@ export function* eval_call_expr(
         }
 
         const result = yield* eval_bare_statements(fn.body, scope);
+        let ret: RuntimeVal;
         if (result.type === AbruptAlias.Return) {
-            return result.value;
+            ret = result.value;
+        } else {
+            ret = result;
         }
-        return result;
-    }
 
-    throw new RuntimeError(`Du versuchst hier ${JSON.stringify(fn)} als Funktion auszuführen!`, call.codePos);
+        return ret;
+    }  
+
+    throw new RuntimeError(`Du versuchst hier ${formatValue(fn)} als Funktion auszuführen!`, call.codePos);
 }
 
 export function* eval_member_expr(

--- a/src/language/runtime/eval/statements.ts
+++ b/src/language/runtime/eval/statements.ts
@@ -10,7 +10,6 @@ import {
     ForBlock,
     FunctionDefinition,
     IfElseBlock,
-    ObjDeclaration,
     Program,
     ReturnCommand,
     ShowCommand,
@@ -84,69 +83,6 @@ export function* eval_var_declaration(
     }
     declEnv.declareVar(decl.ident, value);
     return value;
-}
-
-export function* eval_obj_declaration(
-    decl: ObjDeclaration,
-    evalEnv: Environment,
-    declEnv: Environment | VarHolder = evalEnv
-): SteppedEval<RuntimeVal> {
-    const cl = evalEnv.lookupVar(decl.classname);
-    if (cl.type != ValueAlias.Class)
-        throw new RuntimeError(
-            `'${decl.classname}' ist kein Klassenname!`,
-            decl.codePos
-        );
-    if (cl.internal)
-        throw new RuntimeError(
-            `Kann kein neues Objekt der Klasse '${decl.classname}' erzeugen.`,
-            decl.codePos
-        );
-
-    const obj: ObjectVal = {
-        type: ValueAlias.Object,
-        cls: cl,
-        ownMembers: new VarHolder(),
-    };
-
-    // calculate arguments of constructor
-    const args: RuntimeVal[] = [];
-    for (const expr of decl.args) {
-        const result = yield* evaluate_expr(expr, evalEnv);
-        args.push(result);
-    }
-
-    const constructorEnv = new Environment(evalEnv);
-
-    // create variables
-    if (args.length != cl.params.length)
-        throw new RuntimeError(
-            `Erwarte ${cl.params.length} Parameter, habe aber ${args.length} erhalten!`,
-            decl.codePos
-        );
-    for (let i = 0; i < cl.params.length; i++) {
-        const param = cl.params[i];
-        const varname = param.ident;
-        const arg = args[i];
-
-        if (param.type != arg.type)
-            throw new RuntimeError(
-                `'${varname}' sollte '${param.type}' sein, ist aber '${arg.type}'`,
-                decl.codePos
-            );
-        constructorEnv.declareVar(varname, args[i]);
-    }
-
-    for (const attr of cl.attributes) {
-        if (attr.kind == StmtKind.ObjDeclaration) {
-            yield* eval_obj_declaration(attr, constructorEnv, obj.ownMembers);
-        } else {
-            yield* eval_var_declaration(attr, constructorEnv, obj.ownMembers);
-        }
-    }
-
-    declEnv.declareVar(decl.ident, obj, false);
-    return obj;
 }
 
 export function* eval_fn_definition(

--- a/src/language/runtime/eval/statements.ts
+++ b/src/language/runtime/eval/statements.ts
@@ -26,7 +26,9 @@ import {
     ForInBlock,
 } from "../../frontend/ast";
 import { CodePosition, ILLEGAL_CODE_POS, TokenType } from "../../frontend/lexer";
-import { ClassPrototype, Environment, VarHolder } from "../environment";
+import { Environment } from "../environment";
+import { VarHolder } from "../environment";
+import { ClassPrototype } from "../environment";
 import { SteppedEval, evaluate, evaluate_expr } from "../interpreter";
 import {
     RuntimeVal,

--- a/src/language/runtime/global-environment.ts
+++ b/src/language/runtime/global-environment.ts
@@ -1,0 +1,291 @@
+import { RuntimeError } from "../../errors";
+import { createSphereClass } from "../../robot/addons/bodies";
+import { createRobotClass, declareRobot } from "../../robot/robot";
+import { createWorldClass } from "../../robot/world";
+import { ENV } from "../../spec";
+import { formatValue } from "../../utils";
+import { Environment } from "./environment";
+import {
+    MK_FLOAT,
+    MK_STRING,
+    ValueAlias,
+    isLikeNumber,
+    MK_BOOL,
+    MK_NATIVE_FN,
+    MK_NULL,
+    MK_NUMBER,
+} from "./values";
+
+export interface GlobalEnvironment extends Environment {
+    // global env holds some special values that we don't want to lookup by name
+}
+
+export function declareGlobalEnv(): GlobalEnvironment {
+    class GlobalEnvironment extends Environment {
+    }
+    const env = new GlobalEnvironment();
+    env.declareVar(ENV.global.const.TRUE, MK_BOOL(true), true);
+    env.declareVar(ENV.global.const.FALSE, MK_BOOL(false), true);
+    env.declareVar(ENV.global.const.NULL, MK_NULL(), true);
+    env.declareVar(ENV.global.const.YELLOW, MK_STRING("Y"), true);
+    env.declareVar(ENV.global.const.RED, MK_STRING("R"), true);
+    env.declareVar(ENV.global.const.GREEN, MK_STRING("G"), true);
+    env.declareVar(ENV.global.const.BLUE, MK_STRING("B"), true);
+
+    env.declareVar(
+        ENV.global.fn.RANDOM_NUMBER,
+        MK_NATIVE_FN(ENV.global.fn.RANDOM_NUMBER, (args) => {
+            let r = 0;
+            let b = 0;
+            if (args.length == 0) {
+                r = 1;
+            } else if (args.length <= 2) {
+                let v1 = args[0];
+                if (v1.type !== ValueAlias.Number)
+                    throw new RuntimeError(
+                        `Erwarte mindestens Zahl als Parameter, nicht '${args[0].type}'!`
+                    );
+                r = v1.value;
+
+                if (args.length == 2) {
+                    let v2 = args[1];
+                    if (v2.type !== ValueAlias.Number)
+                        throw new RuntimeError(
+                            `Erwarte zwei (Komma-)zahlen als Parameter, nicht '${args[0].type}' und '${args[1].type}'!`
+                        );
+                    r = v2.value - v1.value;
+                    b = v1.value;
+                }
+            } else throw new RuntimeError(`Zu viele Parameter!`);
+
+            const n = b + Math.floor(Math.random() * r);
+            return MK_NUMBER(n);
+        }),
+        true
+    );
+
+    env.declareVar(
+        ENV.global.fn.RANDOM_FLOAT,
+        MK_NATIVE_FN(ENV.global.fn.RANDOM_FLOAT, (args) => {
+            let r = 0;
+            let b = 0;
+            if (args.length == 0) {
+                r = 1;
+            } else if (args.length <= 2) {
+                let v1 = args[0];
+                if (!isLikeNumber(v1))
+                    throw new RuntimeError(
+                        `Erwarte mindestens (Komma-)zahl als Parameter, nicht '${args[0].type}'!`
+                    );
+                r = v1.value;
+
+                if (args.length == 2) {
+                    let v2 = args[1];
+                    if (!isLikeNumber(v2))
+                        throw new RuntimeError(
+                            `Erwarte zwei (Komma-)zahlen als Parameter, nicht '${args[0].type}' und '${args[1].type}'!`
+                        );
+                    r = v2.value - v1.value;
+                    b = v1.value;
+                }
+            } else throw new RuntimeError(`Zu viele Parameter!`);
+
+            const n = b + Math.random() * r;
+            return MK_FLOAT(n);
+        }),
+        true
+    );
+
+    env.declareVar(
+        ENV.global.fn.LENGTH,
+        MK_NATIVE_FN(ENV.global.fn.LENGTH, (args) => {
+            if (args.length != 1)
+                throw new RuntimeError(`Erwarte genau eine Liste als Eingabe!`);
+            if (args[0].type != ValueAlias.List)
+                throw new RuntimeError(`Erwarte eine Liste als Eingabe!`);
+            return MK_NUMBER(args[0].elements.length);
+        }),
+        true
+    );
+
+    env.declareVar(
+        ENV.global.fn.TO_TEXT,
+        MK_NATIVE_FN(ENV.global.fn.TO_TEXT, (args) => {
+            if (args.length != 1)
+                throw new RuntimeError(`Erwarte genau einen Eingabewert!`);
+            return MK_STRING(formatValue(args[0]));
+        }),
+        true
+    );
+
+    env.declareVar(
+        ENV.global.fn.JOIN,
+        MK_NATIVE_FN(ENV.global.fn.JOIN, (args) => {
+            if (args.length == 0) return MK_STRING("");
+            if (args[0].type != ValueAlias.String)
+                throw new RuntimeError("Erwarte einen Text als erste Eingabe!");
+            const [sep, ...rest] = args;
+            return MK_STRING(rest.map((v) => formatValue(v)).join(sep.value));
+        }),
+        true
+    );
+
+    env.declareVar(
+        ENV.global.fn.TO_INT,
+        MK_NATIVE_FN(ENV.global.fn.TO_INT, (args) => {
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                (args[0].type != ValueAlias.Number &&
+                    args[0].type != ValueAlias.Float)
+            )
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            return MK_NUMBER(Math.trunc(args[0].value));
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.TO_FLOAT,
+        MK_NATIVE_FN(ENV.global.fn.TO_FLOAT, (args) => {
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                (args[0].type != ValueAlias.Number &&
+                    args[0].type != ValueAlias.Float)
+            )
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            return MK_FLOAT(args[0].value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.TRUNC,
+        MK_NATIVE_FN(ENV.global.fn.TRUNC, (args) => {
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
+            value = Math.trunc(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.CEIL,
+        MK_NATIVE_FN(ENV.global.fn.CEIL, (args) => {
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
+            value = Math.ceil(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.FLOOR,
+        MK_NATIVE_FN(ENV.global.fn.FLOOR, (args) => {
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
+            value = Math.floor(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.ROUND,
+        MK_NATIVE_FN(ENV.global.fn.ROUND, (args) => {
+            if (
+                args.length === 0 ||
+                args.length > 1 ||
+                args[0].type != ValueAlias.Float
+            )
+                throw new RuntimeError("Erwarte eine Kommazahl als Eingabe!");
+            let { value, type } = args[0];
+            value = Math.round(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.SIN,
+        MK_NATIVE_FN(ENV.global.fn.SIN, (args) => {
+            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let { value, type } = args[0];
+            value = Math.sin(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.COS,
+        MK_NATIVE_FN(ENV.global.fn.COS, (args) => {
+            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let { value, type } = args[0];
+            value = Math.cos(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.TAN,
+        MK_NATIVE_FN(ENV.global.fn.TAN, (args) => {
+            if (args.length === 0 || args.length > 1 || !isLikeNumber(args[0]))
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let { value, type } = args[0];
+            value = Math.tan(value);
+            return MK_FLOAT(value);
+        })
+    );
+
+    env.declareVar(
+        ENV.global.fn.ABS,
+        MK_NATIVE_FN(ENV.global.fn.ABS, (args) => {
+            if (args.length === 0 || args.length > 1)
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+            let val = args[0];
+            if (val.type === ValueAlias.Number)
+                return MK_NUMBER(Math.abs(val.value));
+            else if (val.type === ValueAlias.Float)
+                return MK_FLOAT(Math.abs(val.value));
+            else
+                throw new RuntimeError(
+                    "Erwarte eine (Komma-)zahl als Eingabe!"
+                );
+        })
+    );
+
+    env.declareVar(ENV.robot.cls, createRobotClass(env), true);
+    env.declareVar(ENV.world.cls, createWorldClass(env), true);
+
+    env.declareVar("Kugel", createSphereClass(), true);
+
+    return env;
+}
+
+

--- a/src/language/runtime/global-environment.ts
+++ b/src/language/runtime/global-environment.ts
@@ -283,7 +283,8 @@ export function declareGlobalEnv(): GlobalEnvironment {
     env.declareVar(ENV.robot.cls, createRobotClass(env), true);
     env.declareVar(ENV.world.cls, createWorldClass(env), true);
 
-    env.declareVar("Kugel", createSphereClass(), true);
+    // TODO: add additional classes
+    // env.declareVar("Kugel", createSphereClass(), true);
 
     return env;
 }

--- a/src/language/runtime/interpreter.ts
+++ b/src/language/runtime/interpreter.ts
@@ -24,6 +24,7 @@ import {
     eval_member_expr,
     eval_list_literal,
     eval_computed_member_expr,
+    eval_instance_expr,
 } from "./eval/expressions";
 import {
     eval_fn_definition,
@@ -35,7 +36,6 @@ import {
     eval_var_declaration,
     eval_while_block,
     eval_class_definition,
-    eval_obj_declaration,
     eval_return_command,
     eval_ext_method_definition,
     eval_always_block,
@@ -84,6 +84,9 @@ export function* evaluate<A extends AbruptStmtKind>(
         case StmtKind.AssignmentExpr:
             yield astNode.codePos;
             return yield* eval_assignment_expr(astNode, env);
+        case StmtKind.InstanceExpr:
+            yield astNode.codePos;
+            return yield* eval_instance_expr(astNode, env);
         case StmtKind.CallExpr:
             yield astNode.codePos;
             return yield* eval_call_expr(astNode, env);
@@ -109,8 +112,6 @@ export function* evaluate<A extends AbruptStmtKind>(
             return yield* eval_switch_block(astNode, env);
         case StmtKind.VarDeclaration:
             return yield* eval_var_declaration(astNode, env);
-        case StmtKind.ObjDeclaration:
-            return yield* eval_obj_declaration(astNode, env);
         case StmtKind.FunctionDefinition:
             return yield* eval_fn_definition(astNode, env);
         case StmtKind.ExtMethodDefinition:

--- a/src/language/runtime/values.ts
+++ b/src/language/runtime/values.ts
@@ -122,7 +122,7 @@ export interface UserClassVal {
     params: ParamDeclaration[]; // for constructor
 }
 
-export type ClassVal = BuiltinClassVal<any> | UserClassVal;
+export type ClassVal = BuiltinClassVal<unknown> | UserClassVal;
 
 export interface ObjectVal {
     type: ValueAlias.Object;

--- a/src/language/runtime/values.ts
+++ b/src/language/runtime/values.ts
@@ -1,7 +1,7 @@
 import { RuntimeError } from "../../errors";
 import { mod } from "../../utils";
 import { ObjDeclaration, ParamDeclaration, Stmt, StmtKind, VarDeclaration } from "../frontend/ast";
-import { ClassPrototype, StaticScope, VarHolder } from "./environment";
+import { VarHolder, StaticScope, ClassPrototype } from "./environment";
 
 export const enum ValueAlias {
     Null = "Nix",
@@ -110,7 +110,7 @@ export interface BuiltinClassVal<C> {
     name: string;
     internal: true;
     prototype: ClassPrototype;
-    internalConstructor: ((args: RuntimeVal[]) => C) | null;
+    internalConstructor?: ((args: RuntimeVal[]) => C);
 }
 
 export interface UserClassVal {

--- a/src/language/runtime/values.ts
+++ b/src/language/runtime/values.ts
@@ -105,11 +105,12 @@ export interface MethodVal {
     body: Stmt<StmtKind.ReturnCommand>[];
 }
 
-export interface BuiltinClassVal {
+export interface BuiltinClassVal<C> {
     type: ValueAlias.Class;
     name: string;
     internal: true;
     prototype: ClassPrototype;
+    internalConstructor: ((args: RuntimeVal[]) => C) | null;
 }
 
 export interface UserClassVal {
@@ -121,7 +122,7 @@ export interface UserClassVal {
     params: ParamDeclaration[]; // for constructor
 }
 
-export type ClassVal = BuiltinClassVal | UserClassVal;
+export type ClassVal = BuiltinClassVal<any> | UserClassVal;
 
 export interface ObjectVal {
     type: ValueAlias.Object;

--- a/src/language/runtime/values.ts
+++ b/src/language/runtime/values.ts
@@ -1,6 +1,6 @@
 import { RuntimeError } from "../../errors";
 import { mod } from "../../utils";
-import { ObjDeclaration, ParamDeclaration, Stmt, StmtKind, VarDeclaration } from "../frontend/ast";
+import { ParamDeclaration, Stmt, StmtKind, VarDeclaration } from "../frontend/ast";
 import { VarHolder, StaticScope, ClassPrototype } from "./environment";
 
 export const enum ValueAlias {
@@ -117,7 +117,7 @@ export interface UserClassVal {
     type: ValueAlias.Class;
     name: string;
     internal?: false;
-    attributes: (VarDeclaration | ObjDeclaration)[];
+    attributes: VarDeclaration[];
     prototype: ClassPrototype;
     params: ParamDeclaration[]; // for constructor
 }

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -3,25 +3,32 @@ import { Environment, instanceNativeObjectFromClass } from "../../language/runti
 import { createInternalClass } from "../../language/runtime/environment";
 import { NativeObjectVal } from "../../language/runtime/environment";
 import {
+    BooleanVal,
+    isLikeNumber,
     MK_FLOAT,
     MK_NULL,
+    NumberLikeVal,
+    NumberVal,
     RuntimeVal,
     ValueAlias,
 } from "../../language/runtime/values";
 import { RuntimeError } from "../../errors";
+import { numberLikeArg, tooManyArgs } from "../../utils";
 
 export class Body {
     x: number;
     y: number;
+    z: number;
     color: string;
     strokeColor: string;
     xRot: number;
     yRot: number;
     zRot: number;
 
-    constructor(x: number, y: number, color: string, strokeColor: string) {
+    constructor(x: number, y: number, z: number, color: string, strokeColor: string) {
         this.x = 0;
         this.y = 0;
+        this.z = 0;
         this.color = color;
         this.strokeColor = strokeColor;
         this.xRot = 0;
@@ -30,7 +37,7 @@ export class Body {
     }
 
     draw(p5: p5) {
-        p5.translate(this.x, this.y);
+        p5.translate(this.x, this.y, this.z);
         p5.rotateX(this.xRot);
         p5.rotateY(this.yRot);
         p5.rotateZ(this.zRot);
@@ -49,13 +56,14 @@ export class Box extends Body {
     constructor(
         x: number,
         y: number,
+        z: number,
         color: string,
         strokeColor: string,
         length: number,
         width: number,
         height: number
     ) {
-        super(x, y, color, strokeColor);
+        super(x, y, z, color, strokeColor);
         this.length = length;
         this.width = width;
         this.height = height;
@@ -78,11 +86,12 @@ export class Sphere extends Body {
     constructor(
         x: number,
         y: number,
+        z: number,
         color: string,
         strokeColor: string,
         radius: number
     ) {
-        super(x, y, color, strokeColor);
+        super(x, y, z, color, strokeColor);
         this.radius = radius;
     }
 
@@ -98,11 +107,12 @@ export function createSphereClass() {
     return createInternalClass<Sphere>({
         clsName: "Kugel",
         clsConstructor: (args) => {
-            if (args.length !== 0)
-                throw new RuntimeError(
-                    `Konstruktor von 'Kugel' erwartet 0 Parameter!`
-                );
-            return new Sphere(0, 0, "white", "black", 50);
+            tooManyArgs(args, 4);
+            let x = numberLikeArg(args[0]);
+            let y = numberLikeArg(args[1]);
+            let z = numberLikeArg(args[2]);
+            let r = numberLikeArg(args[3]);
+            return new Sphere(x.value, y.value, z.value, "white", "black", r.value);
         },
         clsMethods: {
             setzeRadius: (o, args) => {

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -1,6 +1,7 @@
 import type * as p5 from "p5";
-import { BuiltinClassVal, ObjectVal, ValueAlias } from "../../language/runtime/values";
-import { ClassPrototype, GlobalEnvironment } from "../../language/runtime/environment";
+import { declareGeneralClass, GlobalEnvironment } from "../../language/runtime/environment";
+import { MK_FLOAT, MK_NULL, ValueAlias } from "../../language/runtime/values";
+import { RuntimeError } from "../../errors";
 
 export class Body {
   x: number;
@@ -12,27 +13,13 @@ export class Body {
   zRot: number;
 
   constructor(x: number, y: number, color: string, strokeColor: string) {
-    this.x = x;
-    this.y = y;
+    this.x = 0;
+    this.y = 0;
     this.color = color;
     this.strokeColor = strokeColor;
     this.xRot = 0;
     this.yRot = 0;
     this.zRot = 0;
-  }
-
-  setColor(color: string) {
-    this.color = color;
-  }
-
-  setPosition(x: number, y: number) {
-    this.x = x;
-    this.y = y;
-  }
-
-  move(dx: number, dy: number) {
-    this.x += dx;
-    this.y += dy;
   }
 
   draw(p5: p5) {
@@ -44,23 +31,19 @@ export class Body {
   }
 }
 
+/**
+ * Box
+ */
 export class Box extends Body {
   length: number;
   width: number;
   height: number;
-
 
   constructor(x: number, y:number, color: string, strokeColor: string, length: number, width: number, height: number) {
     super(x, y, color, strokeColor);
     this.length = length;
     this.width = width;
     this.height = height;
-  }
-
-  setSize(length: number, width: number, height: number) {
-    this.length = length;
-    this.height = height;
-    this.width = width;
   }
 
   draw(p5: p5): void {
@@ -71,15 +54,14 @@ export class Box extends Body {
   }
 }
 
+/**
+ * Sphere
+ */
 export class Sphere extends Body {
   radius: number;
 
   constructor(x: number, y: number, color: string, strokeColor: string, radius: number) {
     super(x, y, color, strokeColor);
-    this.radius = radius;
-  }
-
-  setRadius(radius: number) {
     this.radius = radius;
   }
 
@@ -89,4 +71,24 @@ export class Sphere extends Body {
     p5.sphere(this.radius);
     p5.pop();
   }
+}
+
+export function declareSphereClass(env: GlobalEnvironment) {
+  return declareGeneralClass<Sphere>(
+    "Kugel",
+    {
+      radiusSetzen: (o, args) => {
+        if (args.length !== 1) throw new RuntimeError(`Unpassende Parameteranzahl!`);
+        if (args[0].type !== ValueAlias.Number || args[0].type !== ValueAlias.Number) throw new RuntimeError(`Erwartete eine (Komma-)Zahl!`);
+        o.radius = args[0].value;
+        return MK_NULL();
+      }
+    },
+    {
+      radius: (o) => {
+        return MK_FLOAT(o.radius);
+      }
+    },
+    env
+  )
 }

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -1,5 +1,5 @@
 import type * as p5 from "p5";
-import { declareGeneralClass, GlobalEnvironment } from "../../language/runtime/environment";
+import { declareInternalClass, GlobalEnvironment, wrapProxyObject, ProxyObjectVal } from "../../language/runtime/environment";
 import { MK_FLOAT, MK_NULL, ValueAlias } from "../../language/runtime/values";
 import { RuntimeError } from "../../errors";
 
@@ -74,15 +74,15 @@ export class Sphere extends Body {
 }
 
 export function declareSphereClass(env: GlobalEnvironment) {
-  return declareGeneralClass<Sphere>(
+  return declareInternalClass<Sphere>(
     "Kugel",
     {
-      radiusSetzen: (o, args) => {
+      setzeRadius: (o, args) => {
         if (args.length !== 1) throw new RuntimeError(`Unpassende Parameteranzahl!`);
-        if (args[0].type !== ValueAlias.Number || args[0].type !== ValueAlias.Number) throw new RuntimeError(`Erwartete eine (Komma-)Zahl!`);
+        if (args[0].type !== ValueAlias.Number && args[0].type !== ValueAlias.Float) throw new RuntimeError(`Erwartete eine (Komma-)Zahl!`);
         o.radius = args[0].value;
         return MK_NULL();
-      }
+      },
     },
     {
       radius: (o) => {
@@ -91,4 +91,8 @@ export function declareSphereClass(env: GlobalEnvironment) {
     },
     env
   )
+}
+
+export function instanceSphereObject(o: Sphere, env: GlobalEnvironment): ProxyObjectVal<Sphere> {
+  return wrapProxyObject(o, "Kugel", env);
 }

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -1,105 +1,133 @@
 import type * as p5 from "p5";
-import { GlobalEnvironment, ProxyObjectVal } from "../../language/runtime/environment";
-import { MK_FLOAT, MK_NULL, RuntimeVal, ValueAlias } from "../../language/runtime/values";
+import { Environment, instanceNativeObjectFromClass } from "../../language/runtime/environment";
+import { createInternalClass } from "../../language/runtime/environment";
+import { NativeObjectVal } from "../../language/runtime/environment";
+import {
+    MK_FLOAT,
+    MK_NULL,
+    RuntimeVal,
+    ValueAlias,
+} from "../../language/runtime/values";
 import { RuntimeError } from "../../errors";
 
 export class Body {
-  x: number;
-  y: number;
-  color: string;
-  strokeColor: string;
-  xRot: number;
-  yRot: number;
-  zRot: number;
+    x: number;
+    y: number;
+    color: string;
+    strokeColor: string;
+    xRot: number;
+    yRot: number;
+    zRot: number;
 
-  constructor(x: number, y: number, color: string, strokeColor: string) {
-    this.x = 0;
-    this.y = 0;
-    this.color = color;
-    this.strokeColor = strokeColor;
-    this.xRot = 0;
-    this.yRot = 0;
-    this.zRot = 0;
-  }
+    constructor(x: number, y: number, color: string, strokeColor: string) {
+        this.x = 0;
+        this.y = 0;
+        this.color = color;
+        this.strokeColor = strokeColor;
+        this.xRot = 0;
+        this.yRot = 0;
+        this.zRot = 0;
+    }
 
-  draw(p5: p5) {
-    p5.translate(this.x, this.y);
-    p5.rotateX(this.xRot);
-    p5.rotateY(this.yRot);
-    p5.rotateZ(this.zRot);
-    p5.fill(this.color);
-  }
+    draw(p5: p5) {
+        p5.translate(this.x, this.y);
+        p5.rotateX(this.xRot);
+        p5.rotateY(this.yRot);
+        p5.rotateZ(this.zRot);
+        p5.fill(this.color);
+    }
 }
 
 /**
  * Box
  */
 export class Box extends Body {
-  length: number;
-  width: number;
-  height: number;
+    length: number;
+    width: number;
+    height: number;
 
-  constructor(x: number, y:number, color: string, strokeColor: string, length: number, width: number, height: number) {
-    super(x, y, color, strokeColor);
-    this.length = length;
-    this.width = width;
-    this.height = height;
-  }
+    constructor(
+        x: number,
+        y: number,
+        color: string,
+        strokeColor: string,
+        length: number,
+        width: number,
+        height: number
+    ) {
+        super(x, y, color, strokeColor);
+        this.length = length;
+        this.width = width;
+        this.height = height;
+    }
 
-  draw(p5: p5): void {
-    p5.push();
-    super.draw(p5);
-    p5.box(this.length, this.width, this.height);
-    p5.pop();
-  }
+    draw(p5: p5): void {
+        p5.push();
+        super.draw(p5);
+        p5.box(this.length, this.width, this.height);
+        p5.pop();
+    }
 }
 
 /**
  * Sphere
  */
 export class Sphere extends Body {
-  radius: number;
+    radius: number;
 
-  constructor(x: number, y: number, color: string, strokeColor: string, radius: number) {
-    super(x, y, color, strokeColor);
-    this.radius = radius;
-  }
-
-  draw(p5: p5): void {
-    p5.push();
-    super.draw(p5);
-    p5.sphere(this.radius);
-    p5.pop();
-  }
-}
-
-export function declareSphereClass(env: GlobalEnvironment) {
-  env.declareInternalClass<Sphere>(
-    "Kugel",
-    (args) => {
-      if (args.length !== 0) throw new RuntimeError(`Konstruktor von 'Kugel' erwartet 0 Parameter!`);
-      return new Sphere(0, 0, "white", "black", 50);
-    },
-    {
-      setzeRadius: (o, args) => {
-        if (args.length !== 1) throw new RuntimeError(`Unpassende Parameteranzahl!`);
-        if (args[0].type !== ValueAlias.Number && args[0].type !== ValueAlias.Float) throw new RuntimeError(`Erwartete eine (Komma-)Zahl!`);
-        o.radius = args[0].value;
-        return MK_NULL();
-      },
-    },
-    {
-      radius: (o) => {
-        return MK_FLOAT(o.radius);
-      }
+    constructor(
+        x: number,
+        y: number,
+        color: string,
+        strokeColor: string,
+        radius: number
+    ) {
+        super(x, y, color, strokeColor);
+        this.radius = radius;
     }
-  )
+
+    draw(p5: p5): void {
+        p5.push();
+        super.draw(p5);
+        p5.sphere(this.radius);
+        p5.pop();
+    }
 }
 
-export function wrapSphereObject(o: Sphere, env: GlobalEnvironment): ProxyObjectVal<Sphere> {
-  return env.wrapProxyObject(o, "Kugel");
+export function createSphereClass() {
+    return createInternalClass<Sphere>({
+        clsName: "Kugel",
+        clsConstructor: (args) => {
+            if (args.length !== 0)
+                throw new RuntimeError(
+                    `Konstruktor von 'Kugel' erwartet 0 Parameter!`
+                );
+            return new Sphere(0, 0, "white", "black", 50);
+        },
+        clsMethods: {
+            setzeRadius: (o, args) => {
+                if (args.length !== 1)
+                    throw new RuntimeError(`Unpassende Parameteranzahl!`);
+                if (
+                    args[0].type !== ValueAlias.Number &&
+                    args[0].type !== ValueAlias.Float
+                )
+                    throw new RuntimeError(`Erwartete eine (Komma-)Zahl!`);
+                o.radius = args[0].value;
+                return MK_NULL();
+            },
+        },
+        clsAttributes: {
+            radius: (o) => {
+                return MK_FLOAT(o.radius);
+            },
+        },
+    });
 }
 
-export function instanceSphereObject(args: RuntimeVal[], env: GlobalEnvironment): ProxyObjectVal<Sphere> {
-  return env.instanceProxyObject("Kugel", args);
+export function instanceSphereObject(
+    args: RuntimeVal[],
+    env: Environment
+): NativeObjectVal<Sphere> {
+    return env.instanceNativeObject("Kugel", args);
 }

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -1,0 +1,92 @@
+import type * as p5 from "p5";
+import { BuiltinClassVal, ObjectVal, ValueAlias } from "../../language/runtime/values";
+import { ClassPrototype, GlobalEnvironment } from "../../language/runtime/environment";
+
+export class Body {
+  x: number;
+  y: number;
+  color: string;
+  strokeColor: string;
+  xRot: number;
+  yRot: number;
+  zRot: number;
+
+  constructor(x: number, y: number, color: string, strokeColor: string) {
+    this.x = x;
+    this.y = y;
+    this.color = color;
+    this.strokeColor = strokeColor;
+    this.xRot = 0;
+    this.yRot = 0;
+    this.zRot = 0;
+  }
+
+  setColor(color: string) {
+    this.color = color;
+  }
+
+  setPosition(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+
+  move(dx: number, dy: number) {
+    this.x += dx;
+    this.y += dy;
+  }
+
+  draw(p5: p5) {
+    p5.translate(this.x, this.y);
+    p5.rotateX(this.xRot);
+    p5.rotateY(this.yRot);
+    p5.rotateZ(this.zRot);
+    p5.fill(this.color);
+  }
+}
+
+export class Box extends Body {
+  length: number;
+  width: number;
+  height: number;
+
+
+  constructor(x: number, y:number, color: string, strokeColor: string, length: number, width: number, height: number) {
+    super(x, y, color, strokeColor);
+    this.length = length;
+    this.width = width;
+    this.height = height;
+  }
+
+  setSize(length: number, width: number, height: number) {
+    this.length = length;
+    this.height = height;
+    this.width = width;
+  }
+
+  draw(p5: p5): void {
+    p5.push();
+    super.draw(p5);
+    p5.box(this.length, this.width, this.height);
+    p5.pop();
+  }
+}
+
+export class Sphere extends Body {
+  radius: number;
+
+  constructor(x: number, y: number, color: string, strokeColor: string, radius: number) {
+    super(x, y, color, strokeColor);
+    this.radius = radius;
+  }
+
+  setRadius(radius: number) {
+    this.radius = radius;
+  }
+
+  draw(p5: p5): void {
+    p5.push();
+    super.draw(p5);
+    p5.sphere(this.radius);
+    p5.pop();
+  }
+}

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -1,6 +1,6 @@
 import type * as p5 from "p5";
-import { declareInternalClass, GlobalEnvironment, wrapProxyObject, ProxyObjectVal } from "../../language/runtime/environment";
-import { MK_FLOAT, MK_NULL, ValueAlias } from "../../language/runtime/values";
+import { GlobalEnvironment, ProxyObjectVal } from "../../language/runtime/environment";
+import { MK_FLOAT, MK_NULL, RuntimeVal, ValueAlias } from "../../language/runtime/values";
 import { RuntimeError } from "../../errors";
 
 export class Body {
@@ -74,8 +74,12 @@ export class Sphere extends Body {
 }
 
 export function declareSphereClass(env: GlobalEnvironment) {
-  return declareInternalClass<Sphere>(
+  env.declareInternalClass<Sphere>(
     "Kugel",
+    (args) => {
+      if (args.length !== 0) throw new RuntimeError(`Konstruktor von 'Kugel' erwartet 0 Parameter!`);
+      return new Sphere(0, 0, "white", "black", 50);
+    },
     {
       setzeRadius: (o, args) => {
         if (args.length !== 1) throw new RuntimeError(`Unpassende Parameteranzahl!`);
@@ -88,11 +92,14 @@ export function declareSphereClass(env: GlobalEnvironment) {
       radius: (o) => {
         return MK_FLOAT(o.radius);
       }
-    },
-    env
+    }
   )
 }
 
-export function instanceSphereObject(o: Sphere, env: GlobalEnvironment): ProxyObjectVal<Sphere> {
-  return wrapProxyObject(o, "Kugel", env);
+export function wrapSphereObject(o: Sphere, env: GlobalEnvironment): ProxyObjectVal<Sphere> {
+  return env.wrapProxyObject(o, "Kugel");
+}
+
+export function instanceSphereObject(args: RuntimeVal[], env: GlobalEnvironment): ProxyObjectVal<Sphere> {
+  return env.instanceProxyObject("Kugel", args);
 }

--- a/src/robot/addons/bodies.ts
+++ b/src/robot/addons/bodies.ts
@@ -1,5 +1,6 @@
+// TODO: Work in progress
 import type * as p5 from "p5";
-import { Environment, instanceNativeObjectFromClass } from "../../language/runtime/environment";
+import { Environment } from "../../language/runtime/environment";
 import { createInternalClass } from "../../language/runtime/environment";
 import { NativeObjectVal } from "../../language/runtime/environment";
 import {

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -52,13 +52,15 @@ interface RobotObjVal extends ObjectVal {
     r: Robot,
 }
 
-export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal {
+// this function should be replaced by declareInternalClass
+export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal<Robot> {
     const prototype = new ClassPrototype();
-    const robotCls: BuiltinClassVal = {
+    const robotCls: BuiltinClassVal<Robot> = {
         type: ValueAlias.Class,
         name: "Roboter",
         internal: true,
         prototype,
+        internalConstructor: null,
     };
 
     function downcastRoboter(self: ObjectVal): asserts self is RobotObjVal {

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -1,9 +1,34 @@
 import { RuntimeError } from "../errors";
-import { ClassPrototype, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
-import { MK_BOOL, MK_STRING, MK_NUMBER, RuntimeVal, BuiltinClassVal, ObjectVal, MK_NATIVE_METHOD, ValueAlias, MK_NULL, MK_NATIVE_GETTER } from "../language/runtime/values";
+import { GlobalEnvironment } from "../language/runtime/global-environment";
+import {
+    createInternalClass,
+    Environment,
+    NativeObjectVal,
+    VarHolder,
+} from "../language/runtime/environment";
+import { ClassPrototype } from "../language/runtime/environment";
+import {
+    MK_BOOL,
+    MK_STRING,
+    MK_NUMBER,
+    RuntimeVal,
+    BuiltinClassVal,
+    ObjectVal,
+    MK_NATIVE_METHOD,
+    ValueAlias,
+    MK_NULL,
+    MK_NATIVE_GETTER,
+} from "../language/runtime/values";
 import { ENV } from "../spec";
 import { easeInOutQuad, toZero, Vec2 } from "../utils";
-import { BlockType, CHAR2BLOCK, CHAR2MARKER, Field, MarkerType, World } from "./world";
+import {
+    BlockType,
+    CHAR2BLOCK,
+    CHAR2MARKER,
+    Field,
+    MarkerType,
+    World,
+} from "./world";
 
 export enum ThoughtType {
     Nothing,
@@ -25,7 +50,7 @@ export enum ThoughtType {
     Robot,
     Yes,
     No,
-    Sees
+    Sees,
 }
 
 export enum OutfitType {
@@ -35,279 +60,234 @@ export enum OutfitType {
 }
 
 export const DIR2GER: Record<string, string> = {
-    "N": "Nord",
-    "E": "Ost",
-    "S": "Süden",
-    "W": "Westen"
-}
+    N: "Nord",
+    E: "Ost",
+    S: "Süden",
+    W: "Westen",
+};
 
 export const DIR2SHORTGER: Record<string, string> = {
-    "N": "N",
-    "E": "O",
-    "S": "S",
-    "W": "W"
-}
+    N: "N",
+    E: "O",
+    S: "S",
+    W: "W",
+};
 
-interface RobotObjVal extends ObjectVal {
-    r: Robot,
-}
+export function createRobotClass(env: Environment) {
+    return createInternalClass<Robot>({
+        clsName: ENV.robot.cls,
+        clsAttributes: {
+            [ENV.robot.attr.X]: (r) => {
+                return MK_NUMBER(r.pos.x);
+            },
+            [ENV.robot.attr.Y]: (r) => {
+                return MK_NUMBER(r.pos.y);
+            },
+            [ENV.robot.attr.DIR]: (r) => {
+                return MK_STRING(DIR2SHORTGER[r.dir]);
+            },
+        },
+        clsMethods: {
+            [ENV.robot.mth.GET_HEIGHT]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.GET_HEIGHT +
+                            `() erwartet keine Parameter!`
+                    );
+                const field = r.world.getField(r.pos.x, r.pos.y)!;
+                return MK_NUMBER(field.blocks.length);
+            },
+            [ENV.robot.mth.STEP]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.STEP + `() erwartet keine Parameter!`
+                    );
+                r.step();
+                return MK_STRING(`( ${r.pos.x} | ${r.pos.y} )`);
+            },
+            [ENV.robot.mth.TURN_LEFT]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.TURN_LEFT + `() erwartet keine Parameter!`
+                    );
+                r.turnLeft();
+                return MK_STRING(DIR2GER[r.dir]);
+            },
+            [ENV.robot.mth.TURN_RIGHT]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.TURN_RIGHT +
+                            `() erwartet keine Parameter!`
+                    );
+                r.turnRight();
+                return MK_STRING(DIR2GER[r.dir]);
+            },
+            [ENV.robot.mth.PLACE_BLOCK]: (r, args) => {
+                if (args.length > 1)
+                    throw new RuntimeError(
+                        ENV.robot.mth.PLACE_BLOCK +
+                            `() erwartet einen oder keine Parameter!`
+                    );
+                let col = "R";
+                if (args.length == 1) {
+                    if (args[0].type != ValueAlias.String)
+                        throw new RuntimeError(
+                            "Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!"
+                        );
+                    col = args[0].value;
+                }
+                r.placeBlock(CHAR2BLOCK[col.toLowerCase()]);
+                return MK_STRING(`( ${r.targetPos().x} | ${r.targetPos().y} )`);
+            },
+            [ENV.robot.mth.PICKUP_BLOCK]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.PICKUP_BLOCK +
+                            `() erwartet keine Parameter!`
+                    );
+                const pickedBlock = r.pickUpBlock();
+                if (pickedBlock == undefined)
+                    throw new RuntimeError("Irgendetwas ist schiefgegangen...");
+                return MK_STRING(pickedBlock);
+            },
+            [ENV.robot.mth.SET_MARKER]: (r, args) => {
+                if (args.length > 1)
+                    throw new RuntimeError(
+                        ENV.robot.mth.SET_MARKER +
+                            `() erwartet einen oder keine Parameter, z.B. markSetzen(blau)!`
+                    );
+                let col = "Y";
+                if (args.length == 1) {
+                    if (args[0].type != ValueAlias.String)
+                        throw new RuntimeError(
+                            "Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!"
+                        );
+                    col = args[0].value;
+                }
+                r.setMarker(CHAR2MARKER[col]);
+                return MK_STRING(`( ${r.targetPos().x} | ${r.targetPos().y} )`);
+            },
+            [ENV.robot.mth.REMOVE_MARKER]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.REMOVE_MARKER +
+                            `() erwartet keine Parameter!`
+                    );
+                const removedMarker = r.removeMarker();
+                if (removedMarker == undefined)
+                    throw new RuntimeError("Irgendetwas ist schiefgegangen...");
+                return MK_STRING(removedMarker);
+            },
+            [ENV.robot.mth.IS_ON_MARKER]: (r, args) => {
+                if (args.length > 1)
+                    throw new RuntimeError(
+                        ENV.robot.mth.IS_ON_MARKER +
+                            `() erwartet einen oder keine Parameter, z.B. istAufMarke(blau)!`
+                    );
+                if (args.length == 1) {
+                    if (args[0].type != ValueAlias.String)
+                        throw new RuntimeError(
+                            "Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!"
+                        );
+                    const col = args[0].value;
+                    return MK_BOOL(r.isOnMarker(CHAR2MARKER[col]));
+                } else {
+                    return MK_BOOL(r.isOnMarker());
+                }
+            },
+            [ENV.robot.mth.SEES_BLOCK]: (r, args) => {
+                if (args.length > 1)
+                    throw new RuntimeError(
+                        ENV.robot.mth.SEES_BLOCK +
+                            `() erwartet einen oder keine Parameter, z.B. siehtZiegel(blau)!`
+                    );
+                if (args.length == 1) {
+                    if (args[0].type != ValueAlias.String)
+                        throw new RuntimeError(
+                            "Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!"
+                        );
+                    const col = args[0].value;
+                    return MK_BOOL(r.seesBlock(CHAR2BLOCK[col.toLowerCase()]));
+                } else {
+                    return MK_BOOL(r.seesBlock());
+                }
+            },
+            [ENV.robot.mth.SEES_WALL]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.SEES_WALL + `() erwartet keine Parameter!`
+                    );
+                return MK_BOOL(r.seesWall());
+            },
+            [ENV.robot.mth.SEES_VOID]: (r, args) => {
+                if (args.length != 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.SEES_VOID + `() erwartet keine Parameter!`
+                    );
+                return MK_BOOL(r.seesVoid());
+            },
+            [ENV.robot.mth.SEES_ROBOT]: (r, args) => {
+                if (args.length > 1)
+                    throw new RuntimeError(
+                        ENV.robot.mth.SEES_ROBOT +
+                            `() erwartet einen oder keinen Parameter!`
+                    );
+                if (args.length == 1) {
+                    if (args[0].type != ValueAlias.Number)
+                        throw new RuntimeError(
+                            `Erwarte eine Zahl als Parameter!`
+                        );
+                    return MK_BOOL(r.seesRobot(args[0].value));
+                } else return MK_BOOL(r.seesRobot(null));
+            },
+            [ENV.robot.mth.CAN_MOVE_HERE]: (r, args) => {
+                if (args.length > 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.CAN_MOVE_HERE +
+                            `() erwartet keine Parameter!`
+                    );
+                try {
+                    r.canMoveTo(r.targetPos());
+                    return MK_BOOL(true);
+                } catch {
+                    return MK_BOOL(false);
+                }
+            },
+            [ENV.robot.mth.WAIT]: (r, args) => {
+                if (args.length > 0)
+                    throw new RuntimeError(
+                        ENV.robot.mth.WAIT + `() erwartet keine Parameter!`
+                    );
+                r.wait();
+                return MK_NULL();
+            },
+            [ENV.robot.mth.DON]: (r, args) => {
+                if (args.length > 1)
+                    throw new RuntimeError(
+                        ENV.robot.mth.DON + `() erwartet genau einen Parameter!`
+                    );
+                if (args[0].type !== ValueAlias.String)
+                    throw new RuntimeError(`Erwarte einen Text als Parameter!`);
 
-// this function should be replaced by declareInternalClass
-export function declareRobotClass(env: GlobalEnvironment): BuiltinClassVal<Robot> {
-    const prototype = new ClassPrototype();
-    const robotCls: BuiltinClassVal<Robot> = {
-        type: ValueAlias.Class,
-        name: "Roboter",
-        internal: true,
-        prototype,
-        internalConstructor: null,
-    };
-
-    function downcastRoboter(self: ObjectVal): asserts self is RobotObjVal {
-        if (!Object.is(self.cls, robotCls))
-            throw new RuntimeError(`Diese Methode kann nur auf Robotern ausgeführt werden.`);
-    }
-    function mkRobotMethod(name: string, m: (r: Robot, args: RuntimeVal[]) => RuntimeVal) {
-        prototype.declareMethod(name, MK_NATIVE_METHOD(name, function (args) {
-            downcastRoboter(this);
-            return m(this.r, args);
-        }))
-    }
-    function mkRobotAttribute(name: string, m: (r: Robot) => RuntimeVal) {
-        prototype.declareMethod(name, MK_NATIVE_GETTER(name, function () {
-            downcastRoboter(this);
-            return m(this.r);
-        }))
-    }
-
-    mkRobotAttribute(
-        ENV.robot.attr.X,
-        (r) => {
-            return MK_NUMBER(r.pos.x);
-        }
-    );
-
-    mkRobotAttribute(
-        ENV.robot.attr.Y,
-        (r) => {
-            return MK_NUMBER(r.pos.y);
-        }
-    );
-
-    mkRobotAttribute(
-        ENV.robot.attr.DIR,
-        (r) => {
-            return MK_STRING(DIR2SHORTGER[r.dir]);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.GET_HEIGHT,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.GET_HEIGHT + `() erwartet keine Parameter!`);
-            const field = r.world.getField(r.pos.x, r.pos.y)!;
-            return MK_NUMBER(field.blocks.length);
-        }
-    );
-    
-    mkRobotMethod(
-        ENV.robot.mth.STEP,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.STEP + `() erwartet keine Parameter!`);
-            r.step();
-            return MK_STRING(`( ${r.pos.x} | ${r.pos.y} )`);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.TURN_LEFT,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.TURN_LEFT + `() erwartet keine Parameter!`);
-            r.turnLeft();
-            return MK_STRING(DIR2GER[r.dir]);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.TURN_RIGHT,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.TURN_RIGHT + `() erwartet keine Parameter!`);
-            r.turnRight();
-            return MK_STRING(DIR2GER[r.dir]);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.PLACE_BLOCK,
-        (r, args) => {
-            if (args.length > 1)
-                throw new RuntimeError(ENV.robot.mth.PLACE_BLOCK + `() erwartet einen oder keine Parameter!`);
-            let col = "R";
-            if (args.length == 1) {
-                if (args[0].type != ValueAlias.String) throw new RuntimeError("Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!");
-                col = args[0].value;
-            }
-            r.placeBlock(CHAR2BLOCK[col.toLowerCase()]);
-            return MK_STRING(`( ${r.targetPos().x} | ${r.targetPos().y} )`);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.PICKUP_BLOCK,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.PICKUP_BLOCK + `() erwartet keine Parameter!`);
-            const pickedBlock = r.pickUpBlock();
-            if (pickedBlock == undefined)
-                throw new RuntimeError("Irgendetwas ist schiefgegangen...");
-            return MK_STRING(pickedBlock);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.SET_MARKER,
-        (r, args) => {
-            if (args.length > 1)
-                throw new RuntimeError(ENV.robot.mth.SET_MARKER + `() erwartet einen oder keine Parameter, z.B. markSetzen(blau)!`);
-            let col = "Y";
-            if (args.length == 1) {
-                if (args[0].type != ValueAlias.String) throw new RuntimeError("Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!");
-                col = args[0].value;
-            }
-            r.setMarker(CHAR2MARKER[col]);
-            return MK_STRING(`( ${r.targetPos().x} | ${r.targetPos().y} )`);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.REMOVE_MARKER,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.REMOVE_MARKER + `() erwartet keine Parameter!`);
-            const removedMarker = r.removeMarker();
-            if (removedMarker == undefined)
-                throw new RuntimeError("Irgendetwas ist schiefgegangen...");
-            return MK_STRING(removedMarker);
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.IS_ON_MARKER,
-        (r, args) => {
-            if (args.length > 1)
-                throw new RuntimeError(ENV.robot.mth.IS_ON_MARKER +`() erwartet einen oder keine Parameter, z.B. istAufMarke(blau)!`);
-            if (args.length == 1) {
-                if (args[0].type != ValueAlias.String) throw new RuntimeError("Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!");
-                const col = args[0].value;
-                return MK_BOOL(r.isOnMarker(CHAR2MARKER[col]));
-            } else {
-                return MK_BOOL(r.isOnMarker());
-            }
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.SEES_BLOCK,
-        (r, args) => {
-            if (args.length > 1)
-                throw new RuntimeError(ENV.robot.mth.SEES_BLOCK + `() erwartet einen oder keine Parameter, z.B. siehtZiegel(blau)!`);
-            if (args.length == 1) {
-                if (args[0].type != ValueAlias.String) throw new RuntimeError("Erwarte 'gelb', 'blau', 'rot' oder 'grün' als Parameter!");
-                const col = args[0].value;
-                return MK_BOOL(r.seesBlock(CHAR2BLOCK[col.toLowerCase()]));
-            } else {
-                return MK_BOOL(r.seesBlock());
-            }
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.SEES_WALL,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.SEES_WALL + `() erwartet keine Parameter!`);
-            return MK_BOOL(r.seesWall());
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.SEES_VOID,
-        (r, args) => {
-            if (args.length != 0)
-                throw new RuntimeError(ENV.robot.mth.SEES_VOID + `() erwartet keine Parameter!`);
-            return MK_BOOL(r.seesVoid());
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.SEES_ROBOT,
-        (r, args) => {
-            if (args.length > 1)
-                throw new RuntimeError(ENV.robot.mth.SEES_ROBOT + `() erwartet einen oder keinen Parameter!`);
-            if (args.length == 1) {
-                if (args[0].type != ValueAlias.Number) throw new RuntimeError(`Erwarte eine Zahl als Parameter!`);
-                return MK_BOOL(r.seesRobot(args[0].value));
-            }
-            else return MK_BOOL(r.seesRobot(null));
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.CAN_MOVE_HERE,
-        (r, args) => {
-            if (args.length > 0)
-                throw new RuntimeError(ENV.robot.mth.CAN_MOVE_HERE + `() erwartet keine Parameter!`);
-            try {
-                r.canMoveTo(r.targetPos());
-                return MK_BOOL(true);
-            } catch {
+                let outfitType = args[0].value as OutfitType;
+                if (Object.values(OutfitType).includes(outfitType)) {
+                    r.setOutfit(outfitType);
+                    return MK_BOOL(true);
+                }
                 return MK_BOOL(false);
-            }
-        }
-    );
-
-    mkRobotMethod(
-        ENV.robot.mth.WAIT,
-        (r, args) => {
-            if (args.length > 0)
-                throw new RuntimeError(ENV.robot.mth.WAIT + `() erwartet keine Parameter!`);
-            r.wait();
-            return MK_NULL();
-        }
-    )
-
-    mkRobotMethod(
-        ENV.robot.mth.DON,
-        (r, args) => {
-            if (args.length > 1)
-                throw new RuntimeError(ENV.robot.mth.DON + `() erwartet genau einen Parameter!`);
-            if (args[0].type !== ValueAlias.String)
-                throw new RuntimeError(`Erwarte einen Text als Parameter!`);
-            
-            let outfitType = args[0].value as OutfitType;
-            if (Object.values(OutfitType).includes(outfitType)) {
-                r.setOutfit(outfitType);
-                return MK_BOOL(true);
-            }
-            return MK_BOOL(false);
-        }
-    )
-
-    return robotCls;
+            },
+        },
+    });
 }
 
-export function declareRobot(r: Robot, varname: string, env: GlobalEnvironment): void {
-    const karol_env = new VarHolder();
-    const robot: RobotObjVal = {
-        type: ValueAlias.Object,
-        cls: env.robotClass,
-        ownMembers: karol_env,
-        r,
-    };
+export function declareRobot(
+    r: Robot,
+    varname: string,
+    env: GlobalEnvironment
+): void {
+    const robot: NativeObjectVal<Robot> = env.wrapNativeObject(
+        ENV.robot.cls, r
+    )
 
     // add robot to environment
     env.declareVar(varname, robot, true);
@@ -322,11 +302,20 @@ export class Robot {
     world: World;
     outfit: OutfitType;
 
-    constructor(x: number, y: number, dir: string, name: string, index: number, w: World) {
+    constructor(
+        x: number,
+        y: number,
+        dir: string,
+        name: string,
+        index: number,
+        w: World
+    ) {
         this.pos = new Vec2(x, y);
         this.moveH = 0.0;
         if (!["N", "E", "S", "W"].includes(dir))
-            throw new RuntimeError(`${name}: '${dir}' ist keine valide Richtung!`);
+            throw new RuntimeError(
+                `${name}: '${dir}' ist keine valide Richtung!`
+            );
         this.dir = dir;
         this.name = name;
         this.index = index;
@@ -374,16 +363,16 @@ export class Robot {
     turnRight() {
         switch (this.dir) {
             case "N":
-                this.dir = "E"
+                this.dir = "E";
                 break;
             case "E":
-                this.dir = "S"
+                this.dir = "S";
                 break;
             case "S":
-                this.dir = "W"
+                this.dir = "W";
                 break;
             case "W":
-                this.dir = "N"
+                this.dir = "N";
                 break;
         }
         // animation
@@ -394,16 +383,16 @@ export class Robot {
     turnLeft() {
         switch (this.dir) {
             case "N":
-                this.dir = "W"
+                this.dir = "W";
                 break;
             case "E":
-                this.dir = "N"
+                this.dir = "N";
                 break;
             case "S":
-                this.dir = "E"
+                this.dir = "E";
                 break;
             case "W":
-                this.dir = "S"
+                this.dir = "S";
                 break;
         }
         /*
@@ -424,11 +413,9 @@ export class Robot {
         if (this.canMoveTo(target)) {
             // this is kinda hacky right now
             const currentField = this.world.getField(this.pos.x, this.pos.y);
-            if (currentField)
-                currentField.wasChanged = true;
+            if (currentField) currentField.wasChanged = true;
             const targetField = this.world.getField(target.x, target.y);
-            if (targetField)
-                targetField.wasChanged = true;
+            if (targetField) targetField.wasChanged = true;
             // the actual movement
             this.pos = target;
         }
@@ -490,11 +477,10 @@ export class Robot {
         try {
             const field = this.world.getField(target.x, target.y)!;
             if (m == null) {
-                if (field.marker != MarkerType.None) check = true
+                if (field.marker != MarkerType.None) check = true;
                 else check = false;
-            }
-            else if (field.marker == m) check = true;
-            else check = false
+            } else if (field.marker == m) check = true;
+            else check = false;
         } catch {
             check = false;
         }
@@ -525,15 +511,14 @@ export class Robot {
     seesBlock(b: BlockType | null = null) {
         // logic
         const target = this.targetPos();
-        
+
         let check = false;
         try {
             const field = this.world.getField(target.x, target.y)!;
             if (b == null) {
                 if (field.blocks.length >= 1) check = true;
                 else check = false;
-            }
-            else if (field.blocks[field.blocks.length - 1] == b) check = true;
+            } else if (field.blocks[field.blocks.length - 1] == b) check = true;
             else check = false;
         } catch {
             check = false;
@@ -589,7 +574,11 @@ export class Robot {
         let check = false;
         const target = this.targetPos();
         for (const r of this.world.robots) {
-            if (r.index != this.index && r.pos.x == target.x && r.pos.y == target.y) {
+            if (
+                r.index != this.index &&
+                r.pos.x == target.x &&
+                r.pos.y == target.y
+            ) {
                 if (index == null || r.index == index) {
                     check = true;
                     break;
@@ -620,7 +609,7 @@ export class Robot {
     isWall(target: Vec2): boolean {
         const targetField = this.world.getField(target.x, target.y);
         if (!targetField) return true;
-        if (targetField.isWall) return true
+        if (targetField.isWall) return true;
         return false;
     }
 
@@ -628,67 +617,126 @@ export class Robot {
         const targetField = this.world.getField(target.x, target.y);
         if (!targetField) return true;
         if (targetField.isEmpty) return true;
-        return false
+        return false;
     }
 
     canMoveTo(target: Vec2): boolean {
         // if there is a world with other robots, etc.
         // check if this robot is legally positioned
         const currentField = this.world.getField(this.pos.x, this.pos.y);
-        if (!currentField) throw new RuntimeError(`${this.name}: Illegale Position!`);
+        if (!currentField)
+            throw new RuntimeError(`${this.name}: Illegale Position!`);
         // check if target field isn't accessible
         const targetField = this.world.getField(target.x, target.y);
-        if (!targetField) throw new RuntimeError(`${this.name}: Dieses Feld existiert nicht!`);
-        if (currentField.getBlockHeight() < targetField.getBlockHeight() - 1) throw new RuntimeError(`${this.name}: Kann diese Höhe hicht überwinden!`);
-        if (currentField.getBlockHeight() > targetField.getBlockHeight() + 1) throw new RuntimeError(`${this.name}: Kann diese Höhe hicht überwinden!`);
-        if (targetField.isEmpty) throw new RuntimeError(`${this.name}: Kann nicht ins Nichts laufen!`);
-        if (targetField.isWall) throw new RuntimeError(`${this.name}: Kann nicht gegen die Wand laufen!`);
+        if (!targetField)
+            throw new RuntimeError(
+                `${this.name}: Dieses Feld existiert nicht!`
+            );
+        if (currentField.getBlockHeight() < targetField.getBlockHeight() - 1)
+            throw new RuntimeError(
+                `${this.name}: Kann diese Höhe hicht überwinden!`
+            );
+        if (currentField.getBlockHeight() > targetField.getBlockHeight() + 1)
+            throw new RuntimeError(
+                `${this.name}: Kann diese Höhe hicht überwinden!`
+            );
+        if (targetField.isEmpty)
+            throw new RuntimeError(
+                `${this.name}: Kann nicht ins Nichts laufen!`
+            );
+        if (targetField.isWall)
+            throw new RuntimeError(
+                `${this.name}: Kann nicht gegen die Wand laufen!`
+            );
         // check if robot is in the way
         const targetRobot = this.world.getRobotAt(target.x, target.y);
-        if (targetRobot) throw new RuntimeError(`${this.name}: Roboter '${targetRobot.name}' ist im Weg!`);
-        return true
+        if (targetRobot)
+            throw new RuntimeError(
+                `${this.name}: Roboter '${targetRobot.name}' ist im Weg!`
+            );
+        return true;
     }
 
     canPlaceAt(targetField: Field | undefined): targetField is Field {
         // check if target field isn't accessible
-        if (!targetField) throw new RuntimeError(`${this.name}: Dieses Feld existiert nicht!`);
-        if (targetField.isEmpty) throw new RuntimeError(`${this.name}: Kann Blöcke nicht ins Nichts legen!`);
-        if (targetField.isWall) throw new RuntimeError(`${this.name}: Kann Blöcke nicht auf Wände legen!`);
-        if (targetField.blocks.length >= targetField.H) throw new RuntimeError(`${this.name}: Kann keinen Block mehr legen, da es keinen Platz mehr gibt!`);
+        if (!targetField)
+            throw new RuntimeError(
+                `${this.name}: Dieses Feld existiert nicht!`
+            );
+        if (targetField.isEmpty)
+            throw new RuntimeError(
+                `${this.name}: Kann Blöcke nicht ins Nichts legen!`
+            );
+        if (targetField.isWall)
+            throw new RuntimeError(
+                `${this.name}: Kann Blöcke nicht auf Wände legen!`
+            );
+        if (targetField.blocks.length >= targetField.H)
+            throw new RuntimeError(
+                `${this.name}: Kann keinen Block mehr legen, da es keinen Platz mehr gibt!`
+            );
         return true;
     }
 
     canPickUpFrom(targetField: Field | undefined): targetField is Field {
         // check if target field isn't accessible
-        if (!targetField) throw new RuntimeError(`${this.name}: Dieses Feld existiert nicht!`);
-        if (targetField.isEmpty) throw new RuntimeError(`${this.name}: Kann Blöcke nicht aus dem Nichts aufheben!`);
-        if (targetField.isWall) throw new RuntimeError(`${this.name}: Kann Wände nicht aufheben!`);
-        if (targetField.blocks.length == 0) throw new RuntimeError(`${this.name}: Kann keinen Block aufheben, weil hier keiner liegt!`);
+        if (!targetField)
+            throw new RuntimeError(
+                `${this.name}: Dieses Feld existiert nicht!`
+            );
+        if (targetField.isEmpty)
+            throw new RuntimeError(
+                `${this.name}: Kann Blöcke nicht aus dem Nichts aufheben!`
+            );
+        if (targetField.isWall)
+            throw new RuntimeError(`${this.name}: Kann Wände nicht aufheben!`);
+        if (targetField.blocks.length == 0)
+            throw new RuntimeError(
+                `${this.name}: Kann keinen Block aufheben, weil hier keiner liegt!`
+            );
         return true;
     }
 
     canMarkAt(targetField: Field | undefined): targetField is Field {
         // check if target field isn't accessible
-        if (!targetField) throw new RuntimeError(`${this.name}: Dieses Feld existiert nicht!`);
-        if (targetField.isEmpty) throw new RuntimeError(`${this.name}: Kann Marker nicht ins Nichts legen!`);
-        if (targetField.isWall) throw new RuntimeError(`${this.name}: Kann Marker nicht auf Wände legen!`);
+        if (!targetField)
+            throw new RuntimeError(
+                `${this.name}: Dieses Feld existiert nicht!`
+            );
+        if (targetField.isEmpty)
+            throw new RuntimeError(
+                `${this.name}: Kann Marker nicht ins Nichts legen!`
+            );
+        if (targetField.isWall)
+            throw new RuntimeError(
+                `${this.name}: Kann Marker nicht auf Wände legen!`
+            );
         return true;
     }
 
     canUnmarkAt(targetField: Field | undefined): targetField is Field {
         // check if target field isn't accessible
-        if (!targetField) throw new RuntimeError(`${this.name}: Dieses Feld existiert nicht!`);
-        if (targetField.isEmpty) throw new RuntimeError(`${this.name}: Kann Marker nicht im Nichts entfernen!`);
-        if (targetField.isWall) throw new RuntimeError(`${this.name}: Kann Marker nicht von Wände entfernen!`);
+        if (!targetField)
+            throw new RuntimeError(
+                `${this.name}: Dieses Feld existiert nicht!`
+            );
+        if (targetField.isEmpty)
+            throw new RuntimeError(
+                `${this.name}: Kann Marker nicht im Nichts entfernen!`
+            );
+        if (targetField.isWall)
+            throw new RuntimeError(
+                `${this.name}: Kann Marker nicht von Wände entfernen!`
+            );
         return true;
     }
 
     /**
      * Animation
-     * 
+     *
      * anim_Prog (progress) variables are timers that count down from 1.0 to 0.0.
      * During this time, the associated animation is active.
-     * 
+     *
      * prepare() updates the robot state FROM an external source,
      * in this case robot-view.ts
      * animate() updates the timers
@@ -724,17 +772,22 @@ export class Robot {
         // update height
         if (this.animCurrHeight != fieldHeight) {
             this.animCurrHeight = fieldHeight;
-            if (this.animCurrHeight != this.animLastHeight) this.triggerFallAnim();
+            if (this.animCurrHeight != this.animLastHeight)
+                this.triggerFallAnim();
         }
         // trigger falls
-        if (this.animFallProg <= 0 || Math.abs(this.animCurrHeight - this.animLastHeight) > 1)
+        if (
+            this.animFallProg <= 0 ||
+            Math.abs(this.animCurrHeight - this.animLastHeight) > 1
+        )
             this.animLastHeight = this.animCurrHeight;
         // auto blink
         if (this.animBlinkProg == 0 && Math.random() < 0.001) {
             this.triggerBlinkAnim();
         }
         // auto reset view
-        if (this.animThoughtProg <= 0) this.animThoughtType = ThoughtType.Nothing;
+        if (this.animThoughtProg <= 0)
+            this.animThoughtType = ThoughtType.Nothing;
     }
 
     animate(deltaProg: number, delta: number): void {

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -18,7 +18,7 @@ import {
     ValueAlias,
 } from "../language/runtime/values";
 import { ENV } from "../spec";
-import { rndi } from "../utils";
+import { formatValue, rndi } from "../utils";
 import { instanceSphereObject, Sphere, type Body } from "./addons/bodies";
 import { declareRobot, Robot } from "./robot";
 import { WorldGen, WorldSource } from "./tasks";
@@ -112,17 +112,6 @@ export function createWorldClass(env: Environment) {
                             `() erwartet keine Parameter!`
                     );
                 return MK_NUMBER(w.getStageIndex() + 1);
-            },
-
-            [ENV.world.mth.CREATE_SPHERE]: (w, args) => {
-                if (args.length != 0)
-                    throw new RuntimeError(
-                        ENV.world.mth.CREATE_SPHERE +
-                            `() erwartet keine Parameter!`
-                    );
-                let ret = instanceSphereObject(args, env);
-                w.decorations.push(ret.nativeRepr);
-                return ret;
             },
         },
     });

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -1,9 +1,9 @@
 import { RuntimeError, WorldError } from "../errors";
-import { ClassPrototype, createGeneralObjectOfClass, declareGeneralObject, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
+import { ClassPrototype, wrapProxyObject, declareProxyObject, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
 import { BuiltinClassVal, MK_BOOL, MK_NATIVE_GETTER, MK_NATIVE_METHOD, MK_NUMBER, ObjectVal, RuntimeVal, ValueAlias } from "../language/runtime/values";
 import { ENV } from "../spec";
 import { rndi } from "../utils";
-import { Sphere, type Body } from "./addons/bodies";
+import { instanceSphereObject, Sphere, type Body } from "./addons/bodies";
 import { declareRobot, Robot } from "./robot";
 import { WorldGen, WorldSource } from "./tasks";
 
@@ -138,7 +138,7 @@ export function declareWorldClass(env: GlobalEnvironment): BuiltinClassVal {
             if (args.length != 0)
                 throw new RuntimeError(ENV.world.mth.CREATE_SPHERE + `() erwartet keine Parameter!`);
             let obj = new Sphere(0, 0, "red", "white", 50);
-            let ret = createGeneralObjectOfClass(obj, env.sphereClass);
+            let ret = instanceSphereObject(obj, env);
             w.decorations.push(obj);
             return ret;
         }

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -3,6 +3,7 @@ import { ClassPrototype, GlobalEnvironment, VarHolder } from "../language/runtim
 import { BuiltinClassVal, MK_BOOL, MK_NATIVE_GETTER, MK_NATIVE_METHOD, MK_NUMBER, ObjectVal, RuntimeVal, ValueAlias } from "../language/runtime/values";
 import { ENV } from "../spec";
 import { rndi } from "../utils";
+import { type Body } from "./addons/bodies";
 import { declareRobot, Robot } from "./robot";
 import { WorldGen, WorldSource } from "./tasks";
 
@@ -157,6 +158,8 @@ export class World {
     stages: string[];
     stageIdx: number = -1;
     goalsRemaining: number = 0;
+
+    decorations: Body[] = [];
 
     constructor(session: number, src: WorldSource, stage: number) {
         this.session = session;

--- a/src/robot/world.ts
+++ b/src/robot/world.ts
@@ -1,9 +1,9 @@
 import { RuntimeError, WorldError } from "../errors";
-import { ClassPrototype, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
+import { ClassPrototype, createGeneralObjectOfClass, declareGeneralObject, GlobalEnvironment, VarHolder } from "../language/runtime/environment";
 import { BuiltinClassVal, MK_BOOL, MK_NATIVE_GETTER, MK_NATIVE_METHOD, MK_NUMBER, ObjectVal, RuntimeVal, ValueAlias } from "../language/runtime/values";
 import { ENV } from "../spec";
 import { rndi } from "../utils";
-import { type Body } from "./addons/bodies";
+import { Sphere, type Body } from "./addons/bodies";
 import { declareRobot, Robot } from "./robot";
 import { WorldGen, WorldSource } from "./tasks";
 
@@ -129,6 +129,18 @@ export function declareWorldClass(env: GlobalEnvironment): BuiltinClassVal {
             if (args.length != 0)
                 throw new RuntimeError(ENV.world.mth.GET_STAGE_INDEX + `() erwartet keine Parameter!`);
             return MK_NUMBER(w.getStageIndex() + 1);
+        }
+    );
+
+    mkWorldMethod(
+        ENV.world.mth.CREATE_SPHERE,
+        (w, args) => {
+            if (args.length != 0)
+                throw new RuntimeError(ENV.world.mth.CREATE_SPHERE + `() erwartet keine Parameter!`);
+            let obj = new Sphere(0, 0, "red", "white", 50);
+            let ret = createGeneralObjectOfClass(obj, env.sphereClass);
+            w.decorations.push(obj);
+            return ret;
         }
     );
 

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -63,6 +63,7 @@ export const ENV = {
         "mth": {
             IS_GOAL_REACHED : "fertig",
             GET_STAGE_INDEX : "teilaufgabe",
+            CREATE_SPHERE : "erzeugeKugel"
         }
     }
 }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -63,7 +63,6 @@ export const ENV = {
         "mth": {
             IS_GOAL_REACHED : "fertig",
             GET_STAGE_INDEX : "teilaufgabe",
-            CREATE_SPHERE : "erzeugeKugel"
         }
     }
 }

--- a/src/ui/flowcharts.ts
+++ b/src/ui/flowcharts.ts
@@ -290,8 +290,6 @@ function chartSimpleStmt(stmt: AnyStmt): ChartNode | undefined {
     switch (stmt.kind) {
         case StmtKind.VarDeclaration:
             return declProc(stmt.ident + " := " + chartExpr(stmt.value).str);
-        case StmtKind.ObjDeclaration:
-            return declProc(stmt.ident + " := " + stmt.classname + "(" + stmt.args.map(chartExpr).map((a) => a.str).join(", ") + ")");
         case StmtKind.EmptyLine:
             return mkIgnore();
         case StmtKind.DocComment:
@@ -325,6 +323,7 @@ function chartSimpleStmt(stmt: AnyStmt): ChartNode | undefined {
                 chartExtMethod(stmt);
             return mkIgnore();
         case StmtKind.AssignmentExpr:
+        case StmtKind.InstanceExpr:
         case StmtKind.BinaryExpr:
         case StmtKind.UnaryExpr:
         case StmtKind.Identifier:
@@ -347,9 +346,13 @@ function chartSimpleStmt(stmt: AnyStmt): ChartNode | undefined {
 
 function chartExpr(expr: Expr): { str: string, type: Type } {
     switch (expr.kind) {
-        case StmtKind.AssignmentExpr:
+        case StmtKind.AssignmentExpr: {
             const val = chartExpr(expr.value);
             return {str: chartExpr(expr.assigne).str + " := " + val.str, type: val.type};
+        }
+        case StmtKind.InstanceExpr: {
+            return {str: expr.classname + "(" + expr.args.map(chartExpr).map((a) => a.str).join(", ") + ")", type: Type.Call};
+        }
         case StmtKind.BinaryExpr:
             const binExprStr = chartExpr(expr.left).str + " " + translateOperator(expr.operator.value) + " " + chartExpr(expr.right).str;
             return {str: expr.inParen ? "(" + binExprStr + ")" : binExprStr, type: Type.Unwrapped};

--- a/src/ui/robot-view.ts
+++ b/src/ui/robot-view.ts
@@ -483,11 +483,20 @@ function robotSketch(p5: p5) {
         p5.push();
         drawWorldOutline(w);
         drawWorldFields(w);
+        drawDecorations(w);
         drawRobots(w);
         drawCompass(w);
         drawRobotThoughts(w);
         p5.pop();
     };
+
+    const drawDecorations = (w: World) => {
+        p5.push();
+        for (const deco of w.decorations) {
+            deco.draw(p5);
+        }
+        p5.pop();
+    }
 
     const drawRobots = (w: World) => {
         p5.push();

--- a/src/ui/store-code.ts
+++ b/src/ui/store-code.ts
@@ -266,11 +266,11 @@ Klasse Vektor
     ende
 ende
 
-Objekt v1 als Vektor
+Objekt v1 sei neuer Vektor
 v1.x ist 4
 v1.y ist 6
 
-Objekt v2 als Vektor
+Objekt v2 sei neuer Vektor
 v2.setzeXY(3, -9)
 
 v1.plus(v2)
@@ -283,7 +283,7 @@ Klasse Foo(Zahl n)
     Zahl zweiBar ist 2 * n
 ende
 
-Objekt f als Foo(4)
+Objekt f sei neues Foo(4)
 zeig f.bar // >> 4
 zeig f.zweiBar // >> 8
 `, false);

--- a/src/ui/store-code.ts
+++ b/src/ui/store-code.ts
@@ -164,9 +164,9 @@ zeig k1.siehtZiegel(gelb) // Gibt wahr zurück, wenn der oberste Ziegel im Stape
 zeig k1.istAufMarke(rot) // Gibt wahr zurück, wenn die Marke unter k1 rot ist.
 // Auch hier ist der Parameter optional.
 
-zeig k1.x() // Gibt die x-Koordinate von k1 zurück.
-zeig k1.y() // Gibt die y-Koordinate zurück.
-zeig k1.richtung() // Gibt die Richtung als Text zurück: "N", "S", "W" oder "O".
+zeig k1.x // Gibt die x-Koordinate von k1 zurück.
+zeig k1.y // Gibt die y-Koordinate zurück.
+zeig k1.richtung // Gibt die Richtung als Text zurück: "N", "S", "W" oder "O".
 
 // im Debugbereich können weitere Robotermethoden eingesehen werden
 `, false);
@@ -184,7 +184,7 @@ ende
 
 // k1 dreht sich solange, bis er nach Norden schaut
 // Mehr zu = und anderen Vergleichsoperatoren später
-wiederhole solange nicht (k1.richtung() == "N")
+wiederhole solange nicht (k1.richtung == "N")
     k1.linksDrehen()
 ende
 

--- a/src/ui/store-code.ts
+++ b/src/ui/store-code.ts
@@ -211,9 +211,9 @@ ende
 
 // Auch 'sonst wenn' ist legal...
 // ... wird aber als geschachtelte bedingte Anweisung interpretiert.
-wenn k1.x() > 0 dann
+wenn k1.x > 0 dann
     k1.schritt()
-sonst wenn k1.y() > 0 dann
+sonst wenn k1.y > 0 dann
     k1.linksDrehen()
     k1.schritt()
 sonst
@@ -310,28 +310,30 @@ Methode feldAufräumen() für Roboter
     ende
 ende
 
-k1.umdrehen() // Funktioniert!
+zeig k1.gehen(3) // nicht kollidiert...
+k1.umdrehen()
+zeig k1.gehen(5) // kollidiert!
 `, false);
 
 storeRawCode("Tutorial: Kommazahlen", `// Kommazahlen
 zeig "Ganze Zahl:"
 Zahl N sei zufallszahl(-100, 100)
-zeig "* N =", N
-zeig "* als Kommazahl", zuKommazahl(N)
-zeig "* |N| =", betrag(N)
+zeig "N =", N
+zeig "als Kommazahl", zuKommazahl(N)
+zeig "|N| =", betrag(N)
 
 zeig ""
 zeig "Kommazahl:"
 Kommazahl z sei zufallsbereich(-100, 100)
-zeig "* z =", z
-zeig "* als ganze Zahl", zuZahl(z)
-zeig "* gestutzt", stutzen(z)
-zeig "* aufgerundet", aufrunden(z)
-zeig "* abgerundet", abrunden(z)
-zeig "* sin(z) =", sin(z)
-zeig "* cos(z) =", cos(z)
-zeig "* tan(z) =", tan(z)
-zeig "* |z| =", betrag(z)
+zeig "z =", z
+zeig "als ganze Zahl", zuZahl(z)
+zeig "gestutzt", stutzen(z)
+zeig "aufgerundet", aufrunden(z)
+zeig "abgerundet", abrunden(z)
+zeig "sin(z) =", sin(z)
+zeig "cos(z) =", cos(z)
+zeig "tan(z) =", tan(z)
+zeig "|z| =", betrag(z)
 `, false);
 
 // retrieve backup, if there is one

--- a/src/ui/structograms.ts
+++ b/src/ui/structograms.ts
@@ -156,7 +156,9 @@ function structure(astNode: Program | AnyStmt): string {
         case StmtKind.UnaryExpr:
             return structureUnaryExpr(astNode);
         case StmtKind.AssignmentExpr:
-            return `${structure(astNode.assigne)} ist ${structure(astNode.value)}`
+            return `${structure(astNode.assigne)} ${astNode.operator.value} ${structure(astNode.value)}`
+        case StmtKind.InstanceExpr:
+            return `${astNode.operator.value} ${astNode.classname}(${astNode.args.map(structure).join(", ")})`
         case StmtKind.CallExpr:
             return `${structure(astNode.ident)}(${astNode.args.map(structure).join(", ")})`
         case StmtKind.MemberExpr:
@@ -165,8 +167,6 @@ function structure(astNode: Program | AnyStmt): string {
             return `${structure(astNode.container)}&lsqb;${structure(astNode.accessor)}&rsqb;`
         case StmtKind.VarDeclaration:
             return `${makeSpan(astNode.type, "struct-type")}</span> <span class="struct-ident">${astNode.ident}</span> ist ${structure(astNode.value)}`
-        case StmtKind.ObjDeclaration:
-            return `${makeSpan("Objekt", "struct-type")} <span class="struct-ident">${astNode.ident}</span> als <span class="struct-classtype">${astNode.classname}</span>`
         case StmtKind.ShowCommand:
             return `${makeSpan("zeig", "struct-cmd")} ${astNode.values.map(structure).join(", ")}`
         case StmtKind.FunctionDefinition:
@@ -409,10 +409,7 @@ function structureClass(node: ClassDefinition): string {
         
         <div class="struct-attributes">
             ${node.attributes.map((attr) => {
-                if (attr.kind == StmtKind.ObjDeclaration)
-                    return `<span class="struct-type">${attr.classname}</span> ${attr.ident}`
-                else
-                    return `<span class="struct-type">${attr.type}</span> ${attr.ident}`
+                return `<span class="struct-type">${attr.type}</span> ${attr.ident}`
             }).join("<br>")}
         </div>
         

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { toPng } from "html-to-image";
-import { RuntimeVal, ValueAlias } from "./language/runtime/values";
+import { NumberLikeVal, RuntimeVal, ValueAlias } from "./language/runtime/values";
+import { RuntimeError } from "./errors";
 
 export class Vec2 {
   x: number = 0;
@@ -198,3 +199,25 @@ export function destructureTaskKey(key: string, containsTitle = false) {
 }
 
 export function mod(l: number, r: number) { return ((l % r) + r) % r };
+
+export function tooFewArgs(expected: ValueAlias): never {
+    throw new RuntimeError(`Zu wenige Parameter! Erwartete '${expected}'`);
+}
+
+export function tooManyArgs(args: RuntimeVal[], expected: number = 0): void {
+    if (args.length > expected) throw new RuntimeError(`Zu viele Parameter! Erwartete ${expected}, erhielt ${args.length}.`);
+}
+
+export function numberLikeArg(given: RuntimeVal | undefined): NumberLikeVal {
+    if (!given) tooFewArgs(ValueAlias.Number);
+    if (given.type !== ValueAlias.Number && given.type !== ValueAlias.Float)
+        throw new RuntimeError(`Erwartete '${ValueAlias.Number}' oder '${ValueAlias.Float}'`);
+    return given;
+}
+
+export function checkAnyArg<R extends RuntimeVal>(given: RuntimeVal | undefined, expected: R["type"]): R {
+    if (!given) tooFewArgs(expected);
+    if (given.type !== expected) 
+        throw new RuntimeError(`Erwartete '${expected}', erhielt '${given.type}'`);
+    return given as R;
+}

--- a/src/wiki/todo.md
+++ b/src/wiki/todo.md
@@ -26,7 +26,8 @@
 
 ### Language features
 
-- [ ] Implement more Pythonic object instantiation like so `Klasse obj sei Klasse()`
+- [ ] Add Typing to functionr returns
+- [x] Implement more Java-like object instantiation like so `Klasse obj sei neue Klasse()`
   - [ ] Implement type checking objects
     - [ ] As function arguments
     - [ ] In assignments

--- a/src/wiki/todo.md
+++ b/src/wiki/todo.md
@@ -26,7 +26,7 @@
 
 ### Language features
 
-- [ ] Add Typing to functionr returns
+- [x] Add Typing to function returns, no checking yet
 - [x] Implement more Java-like object instantiation like so `Klasse obj sei neue Klasse()`
   - [ ] Implement type checking objects
     - [ ] As function arguments

--- a/src/wiki/todo.md
+++ b/src/wiki/todo.md
@@ -10,6 +10,7 @@
   - [x] Using p5.Framebuffers instead of p5.Graphics to draw blocks
   - [x] Using p5.Framebuffers for all graphics, like thoughts and labels
 - [ ] Faster loading - somehow?
+- [ ] Add fun sounds
 
 ### Robots & World
 
@@ -44,6 +45,7 @@
   - [ ] Implement structogram visualization
   - [ ] Implement flowchart visualization
 - [ ] EXTRA MAYBE: Shorthand for `wiederhole` as `wdh.`
+- [ ] Add proper tests
 
 ### Quality of life
 


### PR DESCRIPTION
This PR adds the ability to more easily create bindings for internal classes like World & Robot, even though their implementation is untouched for now. See Sphere-Class for usage.

BuiltinClasses now also include an optional `internalConstructor`, that can be used to create a js-object based directly on RuntimeValues and have it be wrapped in an ObjectVal for use in the environment.

Thus this is the current "object pipeline":
* Declare an internal Class (w/ optional constructor) with `declareInternalClass`
* Then either...
  * Wrap an existing js-object in an ObjectVal with a reference to a declared class with `wrapProxyObject`
  * Instance the js-object through the `internalConstructor` and wrap it in an ObjectVal with `instanceProxyObject`

Together with cac3936356112d4f29444877a7c93621387426a4 this should allow `Objekt kugel = neue Kugel()` or similar of internal classes.

Right now there is no way yet to use the internal constructors directly.